### PR TITLE
Mock single stage

### DIFF
--- a/openwfs/simulation/__init__.py
+++ b/openwfs/simulation/__init__.py
@@ -5,6 +5,7 @@ from . import transmission
 
 from .microscope import Microscope
 from .mockdevices import (
+    Stage,
     XYStage,
     StaticSource,
     Camera,

--- a/openwfs/simulation/mockdevices.py
+++ b/openwfs/simulation/mockdevices.py
@@ -334,6 +334,39 @@ class Camera(ADCProcessor):
     def exposure(self) -> Quantity[u.ms]:
         return self.duration
 
+class Stage(Actuator):
+    """
+    Mimics a single-axis stage actuator.
+    """
+    def __init__(self, axis: str, step_size: Quantity[u.um]):
+        """
+        Args:
+            axis (str): The axis of the stage. Suggested usage is single characters (i.e. 'x', 'y', 'z').
+            step_size (Quantity[u.um]): The step size of the stage.
+        """
+        super().__init__(duration=0 * u.ms, latency=0 * u.ms)
+        self._position = 0.0 * u.um
+        self._axis = axis
+        self._step_size = step_size.to(u.um)
+
+    @property
+    def axis(self) -> str:
+        return self._axis
+    
+    @property
+    def step_size(self) -> Quantity[u.um]:
+        return self._step_size
+
+    @property
+    def position(self) -> Quantity[u.um]:
+        return self._position
+
+    @position.setter
+    def position(self, value: Quantity[u.um]):
+        self._position = self.step_size * np.round(value.to(u.um) / self.step_size)
+    
+    def home(self):
+        self._position = 0.0 * u.um
 
 class XYStage(Actuator):
     """

--- a/openwfs/simulation/mockdevices.py
+++ b/openwfs/simulation/mockdevices.py
@@ -342,7 +342,7 @@ class Stage(Actuator):
         """
         Args:
             axis (str): The axis of the stage. Suggested usage is single characters (i.e. 'x', 'y', 'z').
-            step_size (Quantity[u.um]): The step size of the stage.
+            step_size (Quantity[u.um]): The step size of the stage along `axis` (in micrometers).
         """
         super().__init__(duration=0 * u.ms, latency=0 * u.ms)
         self._position = 0.0 * u.um

--- a/tests/test_mock_devices.py
+++ b/tests/test_mock_devices.py
@@ -1,6 +1,9 @@
 import numpy as np
+import astropy.units as u
 
 from ..openwfs.simulation import SLM
+from ..openwfs.simulation import Stage
+from astropy.units import Quantity
 
 
 def test_mock_slm():
@@ -25,3 +28,20 @@ def test_mock_slm():
     slm.update()
     scaled_pattern = np.repeat(np.repeat(pattern, 10, axis=0), 10, axis=1)
     assert np.allclose(slm.phases.read(), scaled_pattern, atol=1.0 * np.pi / 256)
+
+def test_single_stage():
+    stage = Stage("x", Quantity(10, u.um))
+    assert stage.position == 0
+    assert stage.axis == "x"
+
+    stage.position = Quantity(5, u.um)
+    assert stage.position == Quantity(0, u.um)
+
+    stage.position = Quantity(15, u.um)
+    assert stage.position == Quantity(20, u.um)
+
+    stage.position = Quantity(-5, u.um)
+    assert stage.position == Quantity(0, u.um)
+
+    stage.position = Quantity(-15, u.um)
+    assert stage.position == Quantity(-20, u.um)


### PR DESCRIPTION
I'm using openwfs for creating a bundle of [simulators](https://github.com/redsun-acquisition/redsun-simulator) for my project. Since I would like to support creating mocks with arbitrary axis I added a mock device `Stage` for this purpose rather than writing my own so that I can demonstrate the inheritance capabilities.

It's basically the same as `XYStage` but for single axis, where the `axis` string represents as an identification for it.

Also added UTs.