### PR TITLE
Uniform coordinates of patterns and microscope to use normalised pupil coordinates

### DIFF
--- a/examples/slm_demo.py
+++ b/examples/slm_demo.py
@@ -33,7 +33,7 @@ p3.phases = 0.25
 p4.phases = 1
 p4.additive_blend = False
 
-pf.phases = patterns.lens(100, 2, 1 * u.m, 0.8 * u.um, numerical_aperture)
+pf.phases = patterns.lens(100, 1 * u.m, 0.8 * u.um, numerical_aperture)
 rng = np.random.default_rng()
 for n in range(200):
     random_data = rng.random([10, 10], np.float32) * 2.0 * np.pi

--- a/examples/slm_demo.py
+++ b/examples/slm_demo.py
@@ -33,7 +33,7 @@ p3.phases = 0.25
 p4.phases = 1
 p4.additive_blend = False
 
-pf.phases = patterns.lens(100, f=1 * u.m, wavelength=0.8 * u.um, extent=(10 * u.mm, 10 * u.mm))
+pf.phases = patterns.lens(100, 2, 1 * u.m, 0.8 * u.um, numerical_aperture)
 rng = np.random.default_rng()
 for n in range(200):
     random_data = rng.random([10, 10], np.float32) * 2.0 * np.pi

--- a/examples/slm_disk.py
+++ b/examples/slm_disk.py
@@ -23,7 +23,7 @@ phases = np.random.uniform(low=0, high=30, size=(1, 18))
 slm.patches[0].set_phases(phases, update=False)
 
 # add a second patch that corresponds to a linear gradient
-gradient = patterns.tilt(slm_size, (2, 2), (10, 25))
+gradient = patterns.tilt(slm_size, g=(10, 25), extent=(2, 2))
 slm.patches.append(Patch(slm))
 slm.patches[1].set_phases(gradient)
 

--- a/examples/slm_disk.py
+++ b/examples/slm_disk.py
@@ -23,7 +23,7 @@ phases = np.random.uniform(low=0, high=30, size=(1, 18))
 slm.patches[0].set_phases(phases, update=False)
 
 # add a second patch that corresponds to a linear gradient
-gradient = patterns.tilt(slm_size, (10, 25))
+gradient = patterns.tilt(slm_size, (2, 2), (10, 25))
 slm.patches.append(Patch(slm))
 slm.patches[1].set_phases(gradient)
 

--- a/openwfs/algorithms/basic_fourier.py
+++ b/openwfs/algorithms/basic_fourier.py
@@ -102,7 +102,7 @@ class FourierDualReference(DualReference):
             # The natural step to take is the Abbe diffraction limit of the modulated part,
             # which corresponds to a gradient from -π to π over the modulated part.
             # TODO: modify tilt to take a 2-D argument, returning the mode set directly?
-            modes[i] = tilt(self._shape, g=k_i * 0.5 * np.pi)
+            modes[i] = tilt(self._shape, extent=(2, 2), g=k_i * 0.5 * np.pi)
 
         return modes, modes
 

--- a/openwfs/processors/processors.py
+++ b/openwfs/processors/processors.py
@@ -140,10 +140,10 @@ class Roi:
             # for square masks, instead use the actual size
             if self.mask_type == "disk":
                 d = round(self._radius) * 2 + 1
-                self._mask = disk(d, (2, 2), r)
+                self._mask = disk(d, radius=r)
             elif self.mask_type == "gaussian":
                 d = round(self._radius) * 2 + 1
-                self._mask = gaussian(d, (2, 2), self._waist)
+                self._mask = gaussian(d, self._waist)
             else:  # square
                 d = round(self._radius * 2.0)
                 self._mask = np.ones((d, d))

--- a/openwfs/processors/processors.py
+++ b/openwfs/processors/processors.py
@@ -140,10 +140,10 @@ class Roi:
             # for square masks, instead use the actual size
             if self.mask_type == "disk":
                 d = round(self._radius) * 2 + 1
-                self._mask = disk(d, r)
+                self._mask = disk(d, (2, 2), r)
             elif self.mask_type == "gaussian":
                 d = round(self._radius) * 2 + 1
-                self._mask = gaussian(d, self._waist)
+                self._mask = gaussian(d, (2, 2), self._waist)
             else:  # square
                 d = round(self._radius * 2.0)
                 self._mask = np.ones((d, d))

--- a/openwfs/simulation/microscope.py
+++ b/openwfs/simulation/microscope.py
@@ -41,6 +41,7 @@ class Microscope(Processor):
         magnification: float = 1.0,
         xy_stage=None,
         z_stage=None,
+        immersion_refractive_index: Optional[float] = 1.0,
         incident_field: Union[Detector, ArrayLike, None] = None,
         incident_transform: Optional[Transform] = None,
         aberrations: Union[Detector, np.ndarray, None] = None,
@@ -107,6 +108,7 @@ class Microscope(Processor):
         self.aberration_transform = aberration_transform
         self.slm_transform = incident_transform
         self.wavelength = wavelength.to(u.nm)
+        self.immersion_refractive_index = immersion_refractive_index
         self.oversampling_factor = 2.0
         self.xy_stage = xy_stage or XYStage(0.1 * u.um, 0.1 * u.um)
         self.z_stage = z_stage or LinearStage(0.1 * u.um)
@@ -172,10 +174,10 @@ class Microscope(Processor):
         pupil_extent = unitless(self.wavelength / target_pixel_size)
 
         # If the pupil extent is smaller than 2.0 * NA, warn the user
-        if pupil_extent / 2 < self.numerical_aperture:
+        if pupil_extent[0] / 2 < self.numerical_aperture:
             warnings.warn(
                 f"The given grid does not support the spatial frequency components required for the given numerical aperture. \n"
-                f"Currently, the maximum supported NA is {pupil_extent / 2:.2f} for the current settings. \n"
+                f"Currently, the maximum supported NA is {pupil_extent[0] / 2:.2f} for the current settings. \n"
                 f"Either decrease the magnification, decrease the wavelength or increase the pixel size of the source",
                 UserWarning,
             )
@@ -192,7 +194,7 @@ class Microscope(Processor):
         # Add defocus from z-stage
         if self.z_stage is not None:
             phase = propagation(
-                pupil_shape, distance=self.z_stage.position, wavelength=self.wavelength, extent=pupil_extent
+                pupil_shape, distance=self.z_stage.position, wavelength=self.wavelength, extent=pupil_extent, refractive_index=self.immersion_refractive_index
             )
             pupil_field = pupil_field * np.exp(1j * phase)
 

--- a/openwfs/simulation/microscope.py
+++ b/openwfs/simulation/microscope.py
@@ -176,13 +176,13 @@ class Microscope(Processor):
 
         # Compute the field in the pupil plane
         # The aberrations and the SLM phase pattern are both mapped to the pupil plane coordinates
-        pupil_field = patterns.disk(pupil_shape, radius=self.numerical_aperture, extent=pupil_extent)
+        pupil_field = patterns.disk(pupil_shape, pupil_extent, self.numerical_aperture)
         pupil_area = np.sum(pupil_field)  # TODO (efficiency): compute area directly from radius
 
         # Add defocus from z-stage
         if self.z_stage is not None:
             phase = propagation(
-                pupil_shape, distance=self.z_stage.position, wavelength=self.wavelength, extent=pupil_extent
+                pupil_shape, pupil_extent, self.z_stage.position, self.wavelength, 1, self.numerical_aperture
             )
             pupil_field = pupil_field * np.exp(1j * phase)
 

--- a/openwfs/simulation/microscope.py
+++ b/openwfs/simulation/microscope.py
@@ -169,14 +169,14 @@ class Microscope(Processor):
         # TODO: think about what happens when the slm is smaller than the pupil
 
         # condition 1. Extent of pupil in pupil coordinates: Abbe limit should give pixel_size resolution
-        pupil_extent = self.wavelength / target_pixel_size
+        pupil_extent = self.wavelength / target_pixel_size / self.numerical_aperture
 
         # condition 2. Minimum number of pixels in x and y should be data_shape
         pupil_shape = self.data_shape
 
         # Compute the field in the pupil plane
         # The aberrations and the SLM phase pattern are both mapped to the pupil plane coordinates
-        pupil_field = patterns.disk(pupil_shape, pupil_extent, self.numerical_aperture)
+        pupil_field = patterns.disk(pupil_shape, pupil_extent, 1.0)
         pupil_area = np.sum(pupil_field)  # TODO (efficiency): compute area directly from radius
 
         # Add defocus from z-stage
@@ -188,8 +188,8 @@ class Microscope(Processor):
 
         # Project aberrations
         if aberrations is not None:
-            # use default of 2.0 * NA for the extent of the aberration map if no pixel size is provided
-            aberration_extent = (2.0 * self.numerical_aperture,) * 2 if get_pixel_size(aberrations) is None else None
+            # use default of 2.0 for the extent of the aberration map if no pixel size is provided
+            aberration_extent = (2.0, 2.0) if get_pixel_size(aberrations) is None else None
             pupil_field = pupil_field * np.exp(
                 1.0j
                 * project(

--- a/openwfs/simulation/microscope.py
+++ b/openwfs/simulation/microscope.py
@@ -72,6 +72,7 @@ class Microscope(Processor):
             z_stage (Stage): Optional stage object that moves the sample up and down to focus the microscope.
                 Higher values are further away from the microscope objective.
                 Defaults to a MockStage.
+            immersion_refractive_index: The refractive index of the immersion medium.
             incident_field: Produces 2-D complex images containing the field output of the SLM.
                 If no `slm_transform` is specified, the `pixel_size` attribute should
                  correspond to normalized pupil coordinates
@@ -225,10 +226,16 @@ class Microscope(Processor):
                 transform=self.slm_transform,
             )
 
-        psf = np.abs(np.fft.ifft2(pupil_field)) ** self.nonlinearity  # added for 2 pm
+        # Compute the point spread function
+        # This is done by Fourier transforming the pupil field and taking the absolute value squared
+        # Due to condition 1, after the Fourier transform,
+        # the pixel size matches that of the source (the specimen image).
+        # Note: there is no need to `ifftshift` the pupil field, since we are taking the absolute value anyway
+        
+        psf = np.abs(np.fft.ifft2(pupil_field)) ** 2  
         psf = np.fft.ifftshift(psf) * (psf.size / pupil_area)
 
-        psf = psf**2  # added for 2 pm
+        psf = psf**self.nonlinearity  # added for 2 pm
 
         self._psf = psf  # store psf for later inspection
 

--- a/openwfs/simulation/microscope.py
+++ b/openwfs/simulation/microscope.py
@@ -186,17 +186,17 @@ class Microscope(Processor):
 
         # Compute the field in the pupil plane
         # The aberrations and the SLM phase pattern are both mapped to the pupil plane coordinates
-        pupil_field = patterns.disk(pupil_shape, pupil_extent, 1.0)
+        pupil_field = patterns.disk(pupil_shape, radius=1.0, extent=pupil_extent)
         pupil_area = np.sum(pupil_field)  # TODO (efficiency): compute area directly from radius
 
         # Add defocus from z-stage
         if self.z_stage is not None:
             phase = propagation(
                 pupil_shape,
-                extent=pupil_extent,
                 distance=self.z_stage.position,
                 wavelength=self.wavelength,
                 refractive_index=self.immersion_refractive_index,
+                extent=pupil_extent,
                 numerical_aperture=self.numerical_aperture,
             )
             pupil_field = pupil_field * np.exp(1j * phase)
@@ -225,7 +225,6 @@ class Microscope(Processor):
                 out_shape=pupil_shape,
                 transform=self.slm_transform,
             )
-
         # Compute the point spread function
         # This is done by Fourier transforming the pupil field and taking the absolute value squared
         # Due to condition 1, after the Fourier transform,

--- a/openwfs/simulation/microscope.py
+++ b/openwfs/simulation/microscope.py
@@ -197,6 +197,7 @@ class Microscope(Processor):
                 wavelength=self.wavelength,
                 extent=pupil_extent,
                 refractive_index=self.immersion_refractive_index,
+                numerical_aperture=self.numerical_aperture,
             )
             pupil_field = pupil_field * np.exp(1j * phase)
 

--- a/openwfs/simulation/microscope.py
+++ b/openwfs/simulation/microscope.py
@@ -231,8 +231,8 @@ class Microscope(Processor):
         # Due to condition 1, after the Fourier transform,
         # the pixel size matches that of the source (the specimen image).
         # Note: there is no need to `ifftshift` the pupil field, since we are taking the absolute value anyway
-        
-        psf = np.abs(np.fft.ifft2(pupil_field)) ** 2  
+
+        psf = np.abs(np.fft.ifft2(pupil_field)) ** 2
         psf = np.fft.ifftshift(psf) * (psf.size / pupil_area)
 
         psf = psf**self.nonlinearity  # added for 2 pm

--- a/openwfs/simulation/microscope.py
+++ b/openwfs/simulation/microscope.py
@@ -61,7 +61,7 @@ class Microscope(Processor):
             wavelength: Wavelength of the light used for imaging,
                 the wavelength and numerical_aperture together determine the resolution of the microscope.
             nonlinearity: Exponent to which the PSF is raised. This can be used to simulate two-photon microscopy (nonlinearity=2),
-                or multiphoton microscopy in general (nonlinearity > 2). 
+                or multiphoton microscopy in general (nonlinearity > 2).
             magnification: Scalar magnification factor between input and output image.
                 Note that this factor does not affect the effective image resolution.
                 Increasing the magnification will just produce a zoomed-in blurred image.

--- a/openwfs/simulation/microscope.py
+++ b/openwfs/simulation/microscope.py
@@ -11,9 +11,8 @@ from scipy.signal import fftconvolve
 from ..core import Processor, Detector
 from ..plot_utilities import imshow  # noqa - for debugging
 from ..simulation.mockdevices import XYStage, LinearStage, StaticSource
-from ..utilities import project, place, Transform, get_pixel_size, patterns, unitless
+from ..utilities import project, place, Transform, get_pixel_size, patterns
 from ..utilities.patterns import propagation
-from matplotlib import pyplot as plt
 
 
 class Microscope(Processor):
@@ -180,7 +179,7 @@ class Microscope(Processor):
         # TODO: think about what happens when the slm is smaller than the pupil
 
         # condition 1. Extent of pupil in pupil coordinates: Abbe limit should give pixel_size resolution
-        pupil_extent = unitless(self.wavelength / target_pixel_size)
+        pupil_extent = self.wavelength / target_pixel_size
 
         # condition 2. Minimum number of pixels in x and y should be data_shape
         pupil_shape = self.data_shape

--- a/openwfs/simulation/microscope.py
+++ b/openwfs/simulation/microscope.py
@@ -2,6 +2,7 @@ import warnings
 from typing import Optional, Union
 
 import astropy.units as u
+import cv2
 import numpy as np
 from astropy.units import Quantity
 from numpy.typing import ArrayLike
@@ -12,6 +13,7 @@ from ..plot_utilities import imshow  # noqa - for debugging
 from ..simulation.mockdevices import XYStage, LinearStage, StaticSource
 from ..utilities import project, place, Transform, get_pixel_size, patterns, unitless
 from ..utilities.patterns import propagation
+from matplotlib import pyplot as plt
 
 
 class Microscope(Processor):
@@ -100,6 +102,8 @@ class Microscope(Processor):
         if aberrations is not None and not isinstance(aberrations, Detector):
             if get_pixel_size(aberrations) is None:
                 aberrations = StaticSource(aberrations)
+            else:
+                aberrations = StaticSource(aberrations, pixel_size=get_pixel_size(aberrations))
 
         super().__init__(source, aberrations, incident_field, multi_threaded=multi_threaded)
         self._magnification = magnification
@@ -182,7 +186,6 @@ class Microscope(Processor):
                 UserWarning,
             )
 
-
         # condition 2. Minimum number of pixels in x and y should be data_shape
         pupil_shape = self.data_shape
 
@@ -194,7 +197,11 @@ class Microscope(Processor):
         # Add defocus from z-stage
         if self.z_stage is not None:
             phase = propagation(
-                pupil_shape, distance=self.z_stage.position, wavelength=self.wavelength, extent=pupil_extent, refractive_index=self.immersion_refractive_index
+                pupil_shape,
+                distance=self.z_stage.position,
+                wavelength=self.wavelength,
+                extent=pupil_extent,
+                refractive_index=self.immersion_refractive_index,
             )
             pupil_field = pupil_field * np.exp(1j * phase)
 
@@ -210,6 +217,7 @@ class Microscope(Processor):
                     out_extent=pupil_extent,
                     out_shape=pupil_shape,
                     transform=self.aberration_transform,
+                    interp=cv2.INTER_CUBIC,
                 )
             )
 
@@ -222,13 +230,53 @@ class Microscope(Processor):
                 transform=self.slm_transform,
             )
 
+        # plt.figure(figsize=(10, 5))
+        # plt.subplot(1,2, 1)
+        # plt.imshow(np.angle(incident_field), extent=(-pupil_extent[0] / 2, pupil_extent[0] / 2, -pupil_extent[1] / 2, pupil_extent[1] / 2))
+        # plt.colorbar(label="Phase (radians)")
+        # plt.subplot(1,2, 2)
+        # plt.imshow(np.abs(incident_field), extent=(-pupil_extent[0] / 2, pupil_extent[0] / 2, -pupil_extent[1] / 2, pupil_extent[1] / 2))
+        # plt.colorbar(label="Amplitude")
+        # plt.show()
+
+        # plt.figure(figsize=(10, 5))
+        # plt.subplot(1,2, 1)
+        # plt.imshow(np.angle(project(
+        #         incident_field,
+        #         out_extent=pupil_extent,
+        #         out_shape=pupil_shape,
+        #         transform=self.slm_transform,)), extent=(-pupil_extent[0] / 2, pupil_extent[0] / 2, -pupil_extent[1] / 2, pupil_extent[1] / 2))
+        # plt.colorbar(label="Phase (radians)")
+        # plt.subplot(1,2, 2)
+        # plt.imshow(np.abs(project(
+        #         incident_field,
+        #         out_extent=pupil_extent,
+        #         out_shape=pupil_shape,
+        #         transform=self.slm_transform,)), extent=(-pupil_extent[0] / 2, pupil_extent[0] / 2, -pupil_extent[1] / 2, pupil_extent[1] / 2))
+        # plt.colorbar(label="Amplitude")
+        # plt.show()
+
+        # plt.figure(figsize=(10, 5))
+        # plt.subplot(1,2, 1)
+        # plt.imshow(np.abs(pupil_field)*np.angle(pupil_field), extent=(-pupil_extent[0] / 2, pupil_extent[0] / 2, -pupil_extent[1] / 2, pupil_extent[1] / 2))
+        # plt.colorbar(label="Phase (radians)")
+        # plt.subplot(1,2, 2)
+        # plt.imshow(np.abs(pupil_field), extent=(-pupil_extent[0] / 2, pupil_extent[0] / 2, -pupil_extent[1] / 2, pupil_extent[1] / 2))
+        # plt.colorbar(label="Amplitude")
+        # plt.show()
+        # print(np.max(np.abs(pupil_field)*np.angle(pupil_field)),flush=True)
+
         # Compute the point spread function
         # This is done by Fourier transforming the pupil field and taking the absolute value squared
         # Due to condition 1, after the Fourier transform,
         # the pixel size matches that of the source (the specimen image).
         # Note: there is no need to `ifftshift` the pupil field, since we are taking the absolute value anyway
+
         psf = np.abs(np.fft.ifft2(pupil_field)) ** 2
         psf = np.fft.ifftshift(psf) * (psf.size / pupil_area)
+
+        psf = psf**2  # added for 2 pm
+
         self._psf = psf  # store psf for later inspection
 
         return fftconvolve(source, psf, "same")

--- a/openwfs/simulation/microscope.py
+++ b/openwfs/simulation/microscope.py
@@ -193,9 +193,9 @@ class Microscope(Processor):
         if self.z_stage is not None:
             phase = propagation(
                 pupil_shape,
+                extent=pupil_extent,
                 distance=self.z_stage.position,
                 wavelength=self.wavelength,
-                extent=pupil_extent,
                 refractive_index=self.immersion_refractive_index,
                 numerical_aperture=self.numerical_aperture,
             )

--- a/openwfs/simulation/microscope.py
+++ b/openwfs/simulation/microscope.py
@@ -40,6 +40,7 @@ class Microscope(Processor):
         data_shape=None,
         numerical_aperture: float = 1.0,
         wavelength: Quantity[u.nm],
+        nonlinearity: int = 1,
         magnification: float = 1.0,
         xy_stage=None,
         z_stage=None,
@@ -59,6 +60,8 @@ class Microscope(Processor):
             numerical_aperture: Numerical aperture of the microscope objective
             wavelength: Wavelength of the light used for imaging,
                 the wavelength and numerical_aperture together determine the resolution of the microscope.
+            nonlinearity: Exponent to which the PSF is raised. This can be used to simulate two-photon microscopy (nonlinearity=2),
+                or multiphoton microscopy in general (nonlinearity > 2). 
             magnification: Scalar magnification factor between input and output image.
                 Note that this factor does not affect the effective image resolution.
                 Increasing the magnification will just produce a zoomed-in blurred image.
@@ -109,6 +112,7 @@ class Microscope(Processor):
         self._magnification = magnification
         self._data_shape = data_shape if data_shape is not None else source.data_shape
         self.numerical_aperture = numerical_aperture
+        self.nonlinearity = nonlinearity
         self.aberration_transform = aberration_transform
         self.slm_transform = incident_transform
         self.wavelength = wavelength.to(u.nm)
@@ -177,15 +181,6 @@ class Microscope(Processor):
         # condition 1. Extent of pupil in pupil coordinates: Abbe limit should give pixel_size resolution
         pupil_extent = unitless(self.wavelength / target_pixel_size)
 
-        # If the pupil extent is smaller than 2.0 * NA, warn the user
-        if pupil_extent[0] / 2 < self.numerical_aperture:
-            warnings.warn(
-                f"The given grid does not support the spatial frequency components required for the given numerical aperture. \n"
-                f"Currently, the maximum supported NA is {pupil_extent[0] / 2:.2f} for the current settings. \n"
-                f"Either decrease the magnification, decrease the wavelength or increase the pixel size of the source",
-                UserWarning,
-            )
-
         # condition 2. Minimum number of pixels in x and y should be data_shape
         pupil_shape = self.data_shape
 
@@ -230,49 +225,7 @@ class Microscope(Processor):
                 transform=self.slm_transform,
             )
 
-        # plt.figure(figsize=(10, 5))
-        # plt.subplot(1,2, 1)
-        # plt.imshow(np.angle(incident_field), extent=(-pupil_extent[0] / 2, pupil_extent[0] / 2, -pupil_extent[1] / 2, pupil_extent[1] / 2))
-        # plt.colorbar(label="Phase (radians)")
-        # plt.subplot(1,2, 2)
-        # plt.imshow(np.abs(incident_field), extent=(-pupil_extent[0] / 2, pupil_extent[0] / 2, -pupil_extent[1] / 2, pupil_extent[1] / 2))
-        # plt.colorbar(label="Amplitude")
-        # plt.show()
-
-        # plt.figure(figsize=(10, 5))
-        # plt.subplot(1,2, 1)
-        # plt.imshow(np.angle(project(
-        #         incident_field,
-        #         out_extent=pupil_extent,
-        #         out_shape=pupil_shape,
-        #         transform=self.slm_transform,)), extent=(-pupil_extent[0] / 2, pupil_extent[0] / 2, -pupil_extent[1] / 2, pupil_extent[1] / 2))
-        # plt.colorbar(label="Phase (radians)")
-        # plt.subplot(1,2, 2)
-        # plt.imshow(np.abs(project(
-        #         incident_field,
-        #         out_extent=pupil_extent,
-        #         out_shape=pupil_shape,
-        #         transform=self.slm_transform,)), extent=(-pupil_extent[0] / 2, pupil_extent[0] / 2, -pupil_extent[1] / 2, pupil_extent[1] / 2))
-        # plt.colorbar(label="Amplitude")
-        # plt.show()
-
-        # plt.figure(figsize=(10, 5))
-        # plt.subplot(1,2, 1)
-        # plt.imshow(np.abs(pupil_field)*np.angle(pupil_field), extent=(-pupil_extent[0] / 2, pupil_extent[0] / 2, -pupil_extent[1] / 2, pupil_extent[1] / 2))
-        # plt.colorbar(label="Phase (radians)")
-        # plt.subplot(1,2, 2)
-        # plt.imshow(np.abs(pupil_field), extent=(-pupil_extent[0] / 2, pupil_extent[0] / 2, -pupil_extent[1] / 2, pupil_extent[1] / 2))
-        # plt.colorbar(label="Amplitude")
-        # plt.show()
-        # print(np.max(np.abs(pupil_field)*np.angle(pupil_field)),flush=True)
-
-        # Compute the point spread function
-        # This is done by Fourier transforming the pupil field and taking the absolute value squared
-        # Due to condition 1, after the Fourier transform,
-        # the pixel size matches that of the source (the specimen image).
-        # Note: there is no need to `ifftshift` the pupil field, since we are taking the absolute value anyway
-
-        psf = np.abs(np.fft.ifft2(pupil_field)) ** 2
+        psf = np.abs(np.fft.ifft2(pupil_field)) ** self.nonlinearity  # added for 2 pm
         psf = np.fft.ifftshift(psf) * (psf.size / pupil_area)
 
         psf = psf**2  # added for 2 pm

--- a/openwfs/simulation/mockdevices.py
+++ b/openwfs/simulation/mockdevices.py
@@ -437,6 +437,17 @@ class XYStage(Actuator):
     def y(self, value: Quantity[u.um]):
         self._y = self.step_size_y * np.round(value.to(u.um) / self.step_size_y)
 
+    @property
+    def xy(self) -> tuple[Quantity, Quantity]:
+        # get current xy stage position
+        return self._x, self._y
+
+    @xy.setter
+    def xy(self, value: tuple[Quantity, Quantity]):
+        self._x = self.step_size_x * np.round(value[0].to(u.um) / self.step_size_x)
+        self._y = self.step_size_y * np.round(value[1].to(u.um) / self.step_size_y)
+
+
     def home(self):
         self._x = 0.0 * u.um
         self._y = 0.0 * u.um

--- a/openwfs/simulation/mockdevices.py
+++ b/openwfs/simulation/mockdevices.py
@@ -447,7 +447,6 @@ class XYStage(Actuator):
         self._x = self.step_size_x * np.round(value[0].to(u.um) / self.step_size_x)
         self._y = self.step_size_y * np.round(value[1].to(u.um) / self.step_size_y)
 
-
     def home(self):
         self._x = 0.0 * u.um
         self._y = 0.0 * u.um

--- a/openwfs/utilities/__init__.py
+++ b/openwfs/utilities/__init__.py
@@ -1,3 +1,4 @@
+from cv2 import INTER_NEAREST, INTER_LINEAR, INTER_CUBIC
 from . import tests
 from . import patterns_f
 from . import patterns

--- a/openwfs/utilities/__init__.py
+++ b/openwfs/utilities/__init__.py
@@ -1,4 +1,5 @@
 from . import tests
+from . import patterns_f
 from . import patterns
 from . import utilities
 from .patterns import coordinate_range, disk, gaussian, tilt

--- a/openwfs/utilities/patterns.py
+++ b/openwfs/utilities/patterns.py
@@ -30,7 +30,7 @@ For example, a square pattern with anisotropic pixels may be described by shape=
 whereas shape=(80,100) and extent(8,10) describes square pixels that form a rectangle.
 
 In a pupil-conjugate configuration, a disk of extent=(NA, NA) exactly covers the back pupil of the microscope objective.
-The transformation matrix of the SLM should be set such that SLM coordinates correspond to normalized pupil coordinates.
+The transformation matrix of the SLM should be set such that SLM coordinates correspond to normalised pupil coordinates.
 
 The extent may have a unit of measure. In this case, other parameters (such as `radius`) may need to have
 an according unit of measure.
@@ -100,15 +100,10 @@ def tilt(
     so that :math:`\\frac{\\int_0^{2\\pi} \\int_0^1 |Z(\\rho, \\phi)|^2 \\rho d\\rho d\\phi}{\\int_0^{2\\pi} \\int_0^1 \\rho d\\rho d\\phi} = 1`.
 
     Args:
-        shape: see module documentation
-        g(tuple of two floats): gradient vector.
-          This has the unit: 1 / extent.unit.
-          For the default extent of (2.0, 2.0), a value of g=(1,0)
-          corresponds to having a ramp from -2 to +2 over the height of the pattern.
-          With an extent of (2.0, 2.0) covering the full NA,
-          this pattern causes a displacement of -2/π times the Abbe diffraction limit
+        shape: Number of pixels of the returned pattern.
+        extent: extent of the return pattern defined in normalised pupil coordinates, i.e. an extent of (2, 2) covers the entire back pupil plane of a microscope objective.
+        g(tuple of two floats): gradient vector. For an extent of (2,2), the shift in the focal plane is given by (gx, gy) * -2 / π * wavelength / 2 / numerical_aperture_aperture. Where 'numerical_aperture' is the numerical aperture of the microscope objective, and 'wavelength' is the wavelength of the light.
           (Note: a positive x-gradient g causes the focal point to move in the _negative_ x-direction)
-        extent: see module documentation
         phase_offset: optional additional phase offset to be added to the pattern
     """
 
@@ -124,15 +119,16 @@ def lens(
     numerical_aperture: ScalarType,
     offset=None,
 ):
-    """Constructs a square texture that represents a wavefront defocus: (f-sqrt(f²+r²)) · 2π/λ
+    """Constructs a phase mask mimicking a lens: (f-sqrt(f²+r²)) · 2π/λ
 
     `extent`, `wavelength` and `f` should have compatible units (typically astropy length units).
 
     Args:
-        shape(ShapeType): see module documentation
+        shape(ShapeType): number of pixels of the returned pattern.
+        extent(ExtentType): extent of the return pattern defined in normalised pupil coordinates, i.e. an extent of (2, 2) covers the entire back pupil plane of the lens mimicked by the pattern.
         f(ScalarType): focal length
         wavelength(ScalarType): wavelength
-        extent(ExtentType): physical extent of the SLM, same units as `f` and `wavelength`
+        numerical_aperture(ScalarType): numerical aperturn of the lens mimicked by the pattern. This is used to convert the `extent` from normalised pupil coordinates to k-space (unit radians/meter), together with the `wavelength` and `f`.
     """
 
     offset = np.multiply(offset, -1) if offset is not None else None
@@ -160,13 +156,15 @@ def propagation(
     φ = k_z · distance
 
     Args:
-          shape: see module documentation
+          shape: number of pixels of the returned pattern.
+          extent: Extent of the return image. This value is defined in normalised pupil coordinates, i.e. an extent of (2, 2) covers the entire back pupil plane of a microscope objective with NA of `numerical_aperture`.
           distance (ScalarType): physical distance to propagate axially.
           refractive_index (Scalar):
           wavelength (Scalar):
             the numerical aperture, refractive index and wavelength are used
             to convert the `extent` from pupil coordinates to k-space (unit radians/meter),
-          extent: extent of the returned image,r2_range in NA units. To cover the full NA with a square, use (2*NA, 2*NA)
+          numerical_aperture: numerical aperture of the microscope objective. This is used to convert the `extent` from pupil coordinates to k-space, together with the `wavelength` and `refractive_index`.
+
     """
     offset = np.multiply(offset, -1) if offset is not None else None
 
@@ -190,9 +188,9 @@ def disk(
     (x / rx)^2 + (y / ry)^2 <= 1.0
 
     Args:
-          shape: see module documentation
+          shape: number of pixels of the returned pattern.
+          extent: extent of the return pattern. This value is used to compute the coordinates of each pixel of the image. Scaling both the extent and radius by the same factor does not change the returned pattern, but changing their ratio does.
           radius (ScalarType): radius of the disk, should have the same unit as `extent`.
-          extent: see module documentation
           offset: offsets the centre of the disk by offset
     """
 
@@ -212,12 +210,12 @@ def gaussian(
     `waist`, `extent` and the optional `truncation_radius` should all have the same unit.
 
     Args:
-        shape: see module documentation
+        shape: Number of pixels of the returned pattern.
+        extent: Extent of the return pattern. This value is used to compute the coordinates for the Gaussian profile. Changing the ratio of `extent` and `waist` changes the returned pattern, but scaling both by the same factor does not change the returned pattern.
         waist (ScalarType): location of the beam waist (1/e value)
             relative to half of the size of the pattern (i.e. relative to the `radius` of the square)
         truncation_radius (ScalarType): when not None, specifies the radius of a disk that is used to truncate the
             Gaussian. All values outside the disk are set to 0.
-        extent: see module documentation
         offset: offsets the centre of the Gaussian. The centre of the disk is also offsetted by this amount.
 
     """

--- a/openwfs/utilities/patterns.py
+++ b/openwfs/utilities/patterns.py
@@ -21,24 +21,23 @@ indicating the size (shape) in pixels of the returned field. If `shape` is a sca
 used for both axes.
 
 For the coordinates, the OpenGL convention is used, where the coordinates indicate the centers of the pixels.
-By default, the returned pattern is assumed to cover a -1,1 x -1,1 square, 
-which corresponds to a default `extent` parameter of (2.0, 2.0).
+For an extent of (2, 2), the returned pattern is assumed to cover a -1,1 x -1,1 square.
 In this case, the coordinates range from -1+dx/2 to 1-dx/2, where dx=2.0/shape is the pixel size.
 
-Exptent and shape may be specified individually to work with anisotropic pixels or rectangular patterns.
+Extent and shape may be specified individually to work with anisotropic pixels or rectangular patterns.
 For example, a square pattern with anisotropic pixels may be described by shape=(80,100) and extent(2,2)
 whereas shape=(80,100) and extent(8,10) describes square pixels that form a rectangle.
 
-In a pupil-conjugate configuration, a disk of extent=(NA, NA) exactly covers the back pupil of the microscope objective.
-The transformation matrix of the SLM should be set such that SLM coordinates correspond to normalised pupil coordinates.
+The functions were designed to use normalised pupil coordinates (i.e. an extent of (2,2) which covers the entire back focal plane) so they can be used directly in a pupil-conjugate configuration. 
 
-The extent may have a unit of measure. In this case, other parameters (such as `radius`) may need to have
-an according unit of measure.
+Some patterns (e.g. disk) depend on the ratio between the extent and other parameters (e.g. radius) so any coordinate system can be used by tuning both parameters. The documentation is written in terms of normalised pupil coordinates for consistency.
 
 The (0,0) coordinate is always located in the center of the pattern, which may be on a grid point (for odd shape)
 or between grid points (for even shape).
 
 The returned array has a pixel_size property attached.
+
+Functions are available on openwfs.utilities.patterns_f that accept the coordinates as input instead of requiring an extent and shape.
 """
 
 

--- a/openwfs/utilities/patterns.py
+++ b/openwfs/utilities/patterns.py
@@ -5,6 +5,8 @@ from astropy.units import Quantity
 
 from .utilities import ExtentType, CoordinateType, unitless
 
+from . import patterns_f
+
 # shape of a numpy array, or a single integer that is broadcast to a square shape
 ShapeType = Union[int, Sequence[int]]
 
@@ -87,9 +89,10 @@ def r2_range(shape: ShapeType, extent: ExtentType, offset: Optional[CoordinateTy
 
 def tilt(
     shape: ShapeType,
+    extent: ExtentType,
     g: ExtentType,
-    extent: ExtentType = (2.0, 2.0),
     phase_offset: float = 0.0,
+    offset: Optional[CoordinateType] = None,
 ):
     """Constructs a linear gradient pattern φ=2g·r
 
@@ -108,11 +111,19 @@ def tilt(
         extent: see module documentation
         phase_offset: optional additional phase offset to be added to the pattern
     """
-    c0, c1 = coordinate_range(shape, extent * (Quantity(g) * 2.0))
-    return unitless(c0 + (c1 + phase_offset))
+
+    offset = np.multiply(offset, -1) if offset is not None else None
+    return unitless(patterns_f.tilt(*coordinate_range(shape, extent), g=g, phase_offset=phase_offset))
 
 
-def lens(shape: ShapeType, f: ScalarType, wavelength: ScalarType, extent: ExtentType):
+def lens(
+    shape: ShapeType,
+    extent: ExtentType,
+    f: ScalarType,
+    wavelength: ScalarType,
+    numerical_aperture: ScalarType,
+    offset=None,
+):
     """Constructs a square texture that represents a wavefront defocus: (f-sqrt(f²+r²)) · 2π/λ
 
     `extent`, `wavelength` and `f` should have compatible units (typically astropy length units).
@@ -123,16 +134,25 @@ def lens(shape: ShapeType, f: ScalarType, wavelength: ScalarType, extent: Extent
         wavelength(ScalarType): wavelength
         extent(ExtentType): physical extent of the SLM, same units as `f` and `wavelength`
     """
-    r_sqr = r2_range(shape, extent)
-    return unitless((f - np.sqrt(f**2 + r_sqr)) * (2 * np.pi / wavelength))
+
+    offset = np.multiply(offset, -1) if offset is not None else None
+
+    return patterns_f.lens(
+        *coordinate_range(shape, extent, offset=offset),
+        f=f,
+        wavelength=wavelength,
+        numerical_aperture=numerical_aperture,
+    )
 
 
 def propagation(
     shape: ShapeType,
+    extent: ExtentType,
     distance: ScalarType,
     wavelength: ScalarType,
-    extent: ExtentType,
-    refractive_index: ScalarType = 1.0,
+    refractive_index: ScalarType,
+    numerical_aperture: ScalarType,
+    offset=None,
 ):
     """Computes a wavefront that corresponds to digitally propagating the field in the object plane.
 
@@ -148,16 +168,21 @@ def propagation(
             to convert the `extent` from pupil coordinates to k-space (unit radians/meter),
           extent: extent of the returned image,r2_range in NA units. To cover the full NA with a square, use (2*NA, 2*NA)
     """
-    # convert pupil coordinates to absolute k_x, k_y coordinates
-    n_p2 = r2_range(shape, Quantity(extent))
-    n_z = np.sqrt(np.maximum(refractive_index**2 - n_p2, 0.0))
-    return unitless(2.0 * np.pi / wavelength * distance * n_z)
+    offset = np.multiply(offset, -1) if offset is not None else None
+
+    return patterns_f.propagation(
+        *coordinate_range(shape, extent, offset=offset),
+        distance=distance,
+        wavelength=wavelength,
+        refractive_index=refractive_index,
+        numerical_aperture=numerical_aperture,
+    )
 
 
 def disk(
     shape: ShapeType,
-    radius: ScalarType = 1.0,
-    extent: ExtentType = (2.0, 2.0),
+    extent: ExtentType,
+    radius: ScalarType,
     offset: Optional[CoordinateType] = None,
 ):
     """Constructs an image of a centered (ellipsoid) disk.
@@ -171,19 +196,15 @@ def disk(
           offset: offsets the centre of the disk by offset
     """
 
-    if offset is not None:
-        inv_offset = np.multiply(offset, -1.0)
-    else:
-        inv_offset = None
-
-    return 1.0 * (r2_range(shape, extent, inv_offset) < radius**2)
+    offset = np.multiply(offset, -1) if offset is not None else None
+    return patterns_f.disk(*coordinate_range(shape, extent, offset=offset), radius=radius)
 
 
 def gaussian(
     shape: ShapeType,
+    extent: ExtentType,
     waist: ScalarType,
     truncation_radius: ScalarType = None,
-    extent: ExtentType = (2.0, 2.0),
     offset: Optional[CoordinateType] = None,
 ):
     """Constructs an image of a centered Gaussian
@@ -200,14 +221,7 @@ def gaussian(
         offset: offsets the centre of the Gaussian. The centre of the disk is also offsetted by this amount.
 
     """
-    if offset is not None:
-        inv_offset = np.multiply(offset, -1.0)
-    else:
-        inv_offset = None
-
-    r_sqr = r2_range(shape, extent, inv_offset)
-    w2inv = -1.0 / waist**2
-    gauss = np.exp(unitless(r_sqr * w2inv))
-    if truncation_radius is not None:
-        gauss = gauss * disk(shape, truncation_radius, extent=extent, offset=offset)
-    return unitless(gauss)
+    offset = np.multiply(offset, -1) if offset is not None else None
+    return patterns_f.gaussian(
+        *coordinate_range(shape, extent, offset=offset), waist=waist, truncation_radius=truncation_radius
+    )

--- a/openwfs/utilities/patterns.py
+++ b/openwfs/utilities/patterns.py
@@ -158,15 +158,12 @@ def propagation(
           shape: number of pixels of the returned pattern.
           extent: Extent of the return image. This value is defined in normalised pupil coordinates, i.e. an extent of (2, 2) covers the entire back pupil plane of a microscope objective with NA of `numerical_aperture`.
           distance (ScalarType): physical distance to propagate axially.
-          refractive_index (Scalar):
-          wavelength (Scalar):
-            the numerical aperture, refractive index and wavelength are used
-            to convert the `extent` from pupil coordinates to k-space (unit radians/meter),
+          wavelength (Scalar): wavelength of the light.
+          refractive_index (Scalar): refractive index of the medium in which the light is propagating.
           numerical_aperture: numerical aperture of the microscope objective. This is used to convert the `extent` from pupil coordinates to k-space, together with the `wavelength` and `refractive_index`.
 
     """
     offset = np.multiply(offset, -1) if offset is not None else None
-
     return patterns_f.propagation(
         *coordinate_range(shape, extent, offset=offset),
         distance=distance,
@@ -242,4 +239,33 @@ def gaussian(
     offset = np.multiply(offset, -1) if offset is not None else None
     return patterns_f.gaussian(
         *coordinate_range(shape, extent, offset=offset), waist=waist, truncation_radius=truncation_radius
+    )
+
+
+def binary_grating(
+    shape: ShapeType,
+    extent: ExtentType,
+    period: ScalarType,
+    values,
+    angle: ScalarType = 0.0,
+    offset: Optional[CoordinateType] = None,
+):
+    """Constructs a binary grating pattern.
+
+    Args:
+        shape: Number of pixels of the returned pattern.
+        extent: Extent of the return pattern. This value is used to compute the coordinates for the grating pattern. Changing the ratio of `extent` and `period` changes the returned pattern, but scaling both by the same factor does not change the returned pattern.
+        period (ScalarType): period of the grating, should have the same unit as `extent`.
+        values: tuple of two values (v0, v1) that are used for the two levels of the binary grating. For example, for a binary phase grating, these values could be (0, π).
+        angle (ScalarType): angle of the grating in radians. For an angle of 0, the grating is oriented along the x-axis, and for an angle of π/2, the grating is oriented along the y-axis.
+        offset: offsets the centre of the grating by offset
+
+        For a SLM in a pupil-conjugate configuration with an objective: If the extent and periodicity is defined in the normalised pupil coordinates, the image created by the first diffraction order of the grating is shifted in the focal plane by wavelength / period / na * (cos(angle), sin(angle)).
+
+    Returns:
+        An array of the same shape as the input `shape`, containing the phase values of the binary grating pattern.
+    """
+    offset = np.multiply(offset, -1) if offset is not None else None
+    return patterns_f.binary_grating(
+        *coordinate_range(shape, extent, offset=offset), period=period, values=values, angle=angle
     )

--- a/openwfs/utilities/patterns.py
+++ b/openwfs/utilities/patterns.py
@@ -176,6 +176,26 @@ def propagation(
     )
 
 
+def parabolic(
+    shape: ShapeType,
+    extent: ExtentType,
+    parabolic_coef: ScalarType,
+    offset: Optional[CoordinateType] = None,
+):
+    """Constructs a parabolic phase mask: parabolic_coef * (x^2 + y^2)
+
+    `extent` and `parabolic_coef` should have compatible units (typically astropy length units).
+
+    Args:
+          shape: number of pixels of the returned pattern.
+          extent: Extent of the return image. This value is defined in normalised pupil coordinates, i.e. an extent of (2, 2) covers the entire back pupil plane of a microscope objective.
+          parabolic_coef (ScalarType): coefficient of the parabolic phase mask. This is used together with the `extent` to determine the curvature of the parabola.
+
+    """
+    offset = np.multiply(offset, -1) if offset is not None else None
+    return patterns_f.parabolic(*coordinate_range(shape, extent, offset=offset), parabolic_coef=parabolic_coef)
+
+
 def disk(
     shape: ShapeType,
     extent: ExtentType,

--- a/openwfs/utilities/patterns.py
+++ b/openwfs/utilities/patterns.py
@@ -88,8 +88,8 @@ def r2_range(shape: ShapeType, extent: ExtentType, offset: Optional[CoordinateTy
 
 def tilt(
     shape: ShapeType,
-    extent: ExtentType,
     g: ExtentType,
+    extent: ExtentType = (2.0, 2.0),
     phase_offset: float = 0.0,
     offset: Optional[CoordinateType] = None,
 ):
@@ -107,15 +107,18 @@ def tilt(
     """
 
     offset = np.multiply(offset, -1) if offset is not None else None
-    return unitless(patterns_f.tilt(*coordinate_range(shape, extent), g=g, phase_offset=phase_offset))
+    g = Quantity(g)
+    if g.size == 1:
+        g = g.repeat(2)
+    return unitless(patterns_f.tilt(*coordinate_range(shape, extent), gx=g[0], gy=g[1], phase_offset=phase_offset))
 
 
 def lens(
     shape: ShapeType,
-    extent: ExtentType,
     f: Quantity,
     wavelength: Quantity,
     numerical_aperture: float,
+    extent: ExtentType = (2.0, 2.0),
     offset=None,
 ):
     """Constructs a phase mask mimicking a lens: (f-sqrt(f²+r²)) · 2π/λ
@@ -144,11 +147,11 @@ def lens(
 
 def propagation(
     shape: ShapeType,
-    extent: ExtentType,
     distance: Quantity,
     wavelength: Quantity,
-    refractive_index: float,
     numerical_aperture: float,
+    refractive_index: float = 1.0,
+    extent: ExtentType = (2.0, 2.0),
     offset=None,
 ):
     """Computes a wavefront that corresponds to digitally propagating the field in the object plane.
@@ -180,8 +183,8 @@ def propagation(
 
 def parabola(
     shape: ShapeType,
-    extent: ExtentType,
     alpha: ScalarType,
+    extent: ExtentType = (2.0, 2.0),
     offset: Optional[CoordinateType] = None,
 ):
     """Constructs a parabola phase mask: alpha * (x^2 + y^2)
@@ -204,8 +207,8 @@ def parabola(
 
 def disk(
     shape: ShapeType,
-    extent: ExtentType,
-    radius: Quantity,
+    radius: float = 1,
+    extent: ExtentType = (2.0, 2.0),
     offset: Optional[CoordinateType] = None,
 ):
     """Constructs an image of a centered (ellipsoid) disk.
@@ -228,8 +231,8 @@ def disk(
 
 def gaussian(
     shape: ShapeType,
-    extent: ExtentType,
     waist: ScalarType,
+    extent: ExtentType = (2.0, 2.0),
     truncation_radius: ScalarType = None,
     offset: Optional[CoordinateType] = None,
 ):
@@ -255,9 +258,9 @@ def gaussian(
 
 def binary_grating(
     shape: ShapeType,
-    extent: ExtentType,
     period: ScalarType,
-    values,
+    values: Sequence[float],
+    extent: ExtentType = (2.0, 2.0),
     angle: ScalarType = 0.0,
     offset: Optional[CoordinateType] = None,
 ):

--- a/openwfs/utilities/patterns.py
+++ b/openwfs/utilities/patterns.py
@@ -113,9 +113,9 @@ def tilt(
 def lens(
     shape: ShapeType,
     extent: ExtentType,
-    f: ScalarType,
-    wavelength: ScalarType,
-    numerical_aperture: ScalarType,
+    f: Quantity,
+    wavelength: Quantity,
+    numerical_aperture: float,
     offset=None,
 ):
     """Constructs a phase mask mimicking a lens: (f-sqrt(f²+r²)) · 2π/λ
@@ -123,13 +123,15 @@ def lens(
     `extent`, `wavelength` and `f` should have compatible units (typically astropy length units).
 
     Args:
-        shape(ShapeType): number of pixels of the returned pattern.
-        extent(ExtentType): extent of the return pattern defined in normalised pupil coordinates, i.e. an extent of (2, 2) covers the entire back pupil plane of the lens mimicked by the pattern.
-        f(ScalarType): focal length
-        wavelength(ScalarType): wavelength
-        numerical_aperture(ScalarType): numerical aperturn of the lens mimicked by the pattern. This is used to convert the `extent` from normalised pupil coordinates to k-space (unit radians/meter), together with the `wavelength` and `f`.
-    """
+        shape: number of pixels of the returned pattern.
+        extent: extent of the return pattern defined in normalised pupil coordinates, i.e. an extent of (2, 2) covers the entire back pupil plane of the lens mimicked by the pattern.
+        f: focal length
+        wavelength: wavelength
+        numerical_aperture: numerical aperturn of the lens mimicked by the pattern. This is used to convert the `extent` from normalised pupil coordinates to k-space (unit radians/meter), together with the `wavelength` and `f`.
 
+    Returns:
+        An array of the same shape as the input `shape`, containing the phase values of the lens phase mask.
+    """
     offset = np.multiply(offset, -1) if offset is not None else None
 
     return patterns_f.lens(
@@ -143,10 +145,10 @@ def lens(
 def propagation(
     shape: ShapeType,
     extent: ExtentType,
-    distance: ScalarType,
-    wavelength: ScalarType,
-    refractive_index: ScalarType,
-    numerical_aperture: ScalarType,
+    distance: Quantity,
+    wavelength: Quantity,
+    refractive_index: float,
+    numerical_aperture: float,
     offset=None,
 ):
     """Computes a wavefront that corresponds to digitally propagating the field in the object plane.
@@ -157,10 +159,13 @@ def propagation(
     Args:
           shape: number of pixels of the returned pattern.
           extent: Extent of the return image. This value is defined in normalised pupil coordinates, i.e. an extent of (2, 2) covers the entire back pupil plane of a microscope objective with NA of `numerical_aperture`.
-          distance (ScalarType): physical distance to propagate axially.
-          wavelength (Scalar): wavelength of the light.
-          refractive_index (Scalar): refractive index of the medium in which the light is propagating.
-          numerical_aperture: numerical aperture of the microscope objective. This is used to convert the `extent` from pupil coordinates to k-space, together with the `wavelength` and `refractive_index`.
+          distance (Quantity): physical distance to propagate axially.
+          wavelength (Quantity): wavelength of the light.
+          refractive_index (float): refractive index of the medium in which the light is propagating.
+          numerical_aperture (float): numerical aperture of the microscope objective. This is used to convert the `extent` from pupil coordinates to k-space, together with the `wavelength` and `refractive_index`.
+
+    Return
+            An array of the same shape as the input `shape`, containing the phase values of the wavefront.
 
     """
     offset = np.multiply(offset, -1) if offset is not None else None
@@ -186,8 +191,11 @@ def parabola(
     Args:
           shape: number of pixels of the returned pattern.
           extent: Extent of the return image. This value is defined in normalised pupil coordinates, i.e. an extent of (2, 2) covers the entire back pupil plane of a microscope objective.
-          alpha (ScalarType): coefficient of the parabola phase mask. This is used together with the `extent` to determine the curvature of the parabola.
-          offset: offsets the centre of the parabola by offset. If the parabola is not centered on the back pupil plane, the image in the focal plane will be shifted. For an extent of (2, 2), the resulting shift is given by offset * alpha * wavelength / (numerical_aperture * π), where `numerical_aperture` is the numerical aperture of the microscope objective, and `wavelength` is the wavelength of the light.
+          alpha (float): coefficient of the parabola phase mask. This is used together with the `extent` to determine the curvature of the parabola.
+          offset: offsets the centre of the parabola by offset. If the parabola is not centered on the back pupil plane, the image in the focal plane will be shifted. The resulting shift is given by offset * alpha * wavelength / (numerical_aperture * π), where `numerical_aperture` is the numerical aperture of the microscope objective, and `wavelength` is the wavelength of the light.
+
+    Return:
+            An array of the same shape as the input `shape`, containing the phase values of the parabola phase mask.
 
     """
     offset = np.multiply(offset, -1) if offset is not None else None
@@ -197,7 +205,7 @@ def parabola(
 def disk(
     shape: ShapeType,
     extent: ExtentType,
-    radius: ScalarType,
+    radius: Quantity,
     offset: Optional[CoordinateType] = None,
 ):
     """Constructs an image of a centered (ellipsoid) disk.
@@ -209,6 +217,9 @@ def disk(
           extent: extent of the return pattern. This value is used to compute the coordinates of each pixel of the image. Scaling both the extent and radius by the same factor does not change the returned pattern, but changing their ratio does.
           radius (ScalarType): radius of the disk, should have the same unit as `extent`.
           offset: offsets the centre of the disk by offset
+
+    Return:
+            An array of the same shape as the input `shape`, containing the values of the disk pattern. The values are 1 inside the disk and 0 outside the disk.
     """
 
     offset = np.multiply(offset, -1) if offset is not None else None
@@ -229,9 +240,9 @@ def gaussian(
     Args:
         shape: Number of pixels of the returned pattern.
         extent: Extent of the return pattern. This value is used to compute the coordinates for the Gaussian profile. Changing the ratio of `extent` and `waist` changes the returned pattern, but scaling both by the same factor does not change the returned pattern.
-        waist (ScalarType): location of the beam waist (1/e value)
+        waist: location of the beam waist (1/e value)
             relative to half of the size of the pattern (i.e. relative to the `radius` of the square)
-        truncation_radius (ScalarType): when not None, specifies the radius of a disk that is used to truncate the
+        truncation_radius: when not None, specifies the radius of a disk that is used to truncate the
             Gaussian. All values outside the disk are set to 0.
         offset: offsets the centre of the Gaussian. The centre of the disk is also offsetted by this amount.
 

--- a/openwfs/utilities/patterns.py
+++ b/openwfs/utilities/patterns.py
@@ -101,7 +101,7 @@ def tilt(
     Args:
         shape: Number of pixels of the returned pattern.
         extent: extent of the return pattern defined in normalised pupil coordinates, i.e. an extent of (2, 2) covers the entire back pupil plane of a microscope objective.
-        g(tuple of two floats): gradient vector. For an extent of (2,2), the shift in the focal plane is given by (gx, gy) * -2 / π * wavelength / 2 / numerical_aperture_aperture. Where 'numerical_aperture' is the numerical aperture of the microscope objective, and 'wavelength' is the wavelength of the light.
+        g(tuple of two floats): gradient vector. For an extent of (2,2), the shift in the focal plane is given by (gx, gy) * -1 / π * wavelength / numerical_aperture_aperture. Where 'numerical_aperture' is the numerical aperture of the microscope objective, and 'wavelength' is the wavelength of the light.
           (Note: a positive x-gradient g causes the focal point to move in the _negative_ x-direction)
         phase_offset: optional additional phase offset to be added to the pattern
     """
@@ -176,24 +176,25 @@ def propagation(
     )
 
 
-def parabolic(
+def parabola(
     shape: ShapeType,
     extent: ExtentType,
-    parabolic_coef: ScalarType,
+    alpha: ScalarType,
     offset: Optional[CoordinateType] = None,
 ):
-    """Constructs a parabolic phase mask: parabolic_coef * (x^2 + y^2)
+    """Constructs a parabola phase mask: alpha * (x^2 + y^2)
 
-    `extent` and `parabolic_coef` should have compatible units (typically astropy length units).
+    `extent` and `alpha` should have compatible units (typically astropy length units).
 
     Args:
           shape: number of pixels of the returned pattern.
           extent: Extent of the return image. This value is defined in normalised pupil coordinates, i.e. an extent of (2, 2) covers the entire back pupil plane of a microscope objective.
-          parabolic_coef (ScalarType): coefficient of the parabolic phase mask. This is used together with the `extent` to determine the curvature of the parabola.
+          alpha (ScalarType): coefficient of the parabola phase mask. This is used together with the `extent` to determine the curvature of the parabola.
+          offset: offsets the centre of the parabola by offset. If the parabola is not centered on the back pupil plane, the image in the focal plane will be shifted. For an extent of (2, 2), the resulting shift is given by offset * alpha * wavelength / (numerical_aperture * π), where `numerical_aperture` is the numerical aperture of the microscope objective, and `wavelength` is the wavelength of the light.
 
     """
     offset = np.multiply(offset, -1) if offset is not None else None
-    return patterns_f.parabolic(*coordinate_range(shape, extent, offset=offset), parabolic_coef=parabolic_coef)
+    return patterns_f.parabola(*coordinate_range(shape, extent, offset=offset), alpha=alpha)
 
 
 def disk(

--- a/openwfs/utilities/patterns_f.py
+++ b/openwfs/utilities/patterns_f.py
@@ -103,7 +103,7 @@ def propagation(
     k = 2 * np.pi * refractive_index / wavelength
     k_x = k * numerical_aperture * rx
     k_y = k * numerical_aperture * ry
-    k_z = np.sqrt(k**2 - k_x**2 - k_y**2)
+    k_z = np.sqrt(np.maximum(k**2 - k_x**2 - k_y**2, 0))
 
     return unitless(distance * k_z)
 

--- a/openwfs/utilities/patterns_f.py
+++ b/openwfs/utilities/patterns_f.py
@@ -26,7 +26,7 @@ def tilt(
         x: array of the pupil plane coordinates in the x-direction. The shape of x and y should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
         y: array of the pupil plane coordinates in the y-direction. The shape of x and y should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
         g(tuple of two floats): gradient vector.
-            When used in the pupil plane of an objective, this patterns causes a displacement of the beam along the x and y dimensions. For x and y in normalised pupil coodinates (i.e. -1 to 1), this patterns causes a displacement of: (gx, gy) * (-2 /π * λ / 2 / numerical_aperturn).
+            When used in the pupil plane of an objective, this patterns causes a displacement of the beam along the x and y dimensions. For x and y in normalised pupil coodinates (i.e. -1 to 1), this patterns causes a displacement of: (gx, gy) * (-1 /π * λ / numerical_aperturn).
           (Note: a positive x-gradient g causes the focal point to move in the _negative_ x-direction)
         phase_offset: optional additional phase offset to be added to the pattern
 
@@ -136,3 +136,24 @@ def parabola(
         An array of the same shape as x and y (or broadcasted), containing the phase values of the parabola pattern.
     """
     return unitless(alpha * (x**2 + y**2))
+
+
+def binary_grating(x, y, period, values, angle):
+    """
+        Constructs a binary grating pattern with a given period.
+
+    Args:
+        x: array of the normalised pupil plane coordinates in the x-direction
+        y: array of the normalised pupil plane coordinates in the y-direction
+        period: period of the grating in the same units as x and y (i.e. if x and y are in normalised pupil coordinates, the period should also be in normalised pupil coordinates)
+        values: tuple of two values (value for the "up" phase and value for the "down" phase).
+        angle: angle of the grating in radians. An angle of 0 corresponds to a grating that is periodic along the x-direction, and an angle of π/2 corresponds to a grating that is periodic along the y-direction.
+
+    For a SLM in a pupil-conjugate configuration with an objective, the image created by the first order of this grating is shifted by:
+
+    """
+    coord_along_periodic_direction = x * np.cos(angle) + y * np.sin(angle)
+    phase_mask = np.full(coord_along_periodic_direction.shape, values[0])
+    up_values = (coord_along_periodic_direction % period) >= (period / 2)
+    phase_mask[up_values] = values[1]
+    return phase_mask

--- a/openwfs/utilities/patterns_f.py
+++ b/openwfs/utilities/patterns_f.py
@@ -56,8 +56,8 @@ def lens(x, y, f, wavelength, numerical_aperture):
 def propagation(
     x,
     y,
-    distance: ScalarType,
-    wavelength: ScalarType,
+    distance: Quantity,
+    wavelength: Quantity,
     refractive_index: ScalarType,
     numerical_aperture: ScalarType,
 ):
@@ -67,15 +67,15 @@ def propagation(
     Args:
         x: array of the pupil plane coordinates in the x-direction. The shape of x and y should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
         y: array of the pupil plane coordinates in the y-direction. The shape of x and y should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
-        distance (ScalarType): physical distance to propagate axially.
-        refractive_index (Scalar): refractive index of the medium in which the light is propagating.
-        wavelength (Scalar): wavelength of the light.
-        numerical_aperture: numerical aperture of the lens. This is used to convert the pupil-conjugate coordinates x and y to physical units (i.e. to convert from normalised pupil coodinates to k-space coordinates). An x and y of 1 correspond to the edge of the pupil, convering the full numerical aperture of the lens (applied by the phase mask).
+        distance (Quantity): physical distance to propagate axially.
+        wavelength (Quantity): wavelength of the light.
+        refractive_index (ScalarType): refractive index of the medium in which the light is propagating.
+        numerical_aperture (ScalarType): numerical aperture of the lens. This is used to convert the pupil-conjugate coordinates x and y to physical units (i.e. to convert from normalised pupil coodinates to k-space coordinates). An x and y of 1 correspond to the edge of the pupil, convering the full numerical aperture of the lens (applied by the phase mask).
     """
-    k = 2 * np.pi * refractive_index / wavelength
-    k_x = k * numerical_aperture * x
-    k_y = k * numerical_aperture * y
-    k_z = np.sqrt(np.maximum(k**2 - k_x**2 - k_y**2, 0))
+    k_0 = 2 * np.pi / wavelength
+    k_x = k_0 * numerical_aperture * x
+    k_y = k_0 * numerical_aperture * y
+    k_z = np.sqrt(np.maximum((k_0 * refractive_index) ** 2 - k_x**2 - k_y**2, 0))
 
     return unitless(distance * k_z)
 

--- a/openwfs/utilities/patterns_f.py
+++ b/openwfs/utilities/patterns_f.py
@@ -1,0 +1,148 @@
+from typing import Union, Sequence, Optional
+from .utilities import ExtentType, CoordinateType, unitless
+
+import numpy as np
+from astropy.units import Quantity
+
+# shape of a numpy array, or a single integer that is broadcast to a square shape
+ShapeType = Union[int, Sequence[int]]
+
+# a scalar quantity with optional unit attached
+ScalarType = Union[float, np.ndarray, Quantity]
+
+"""
+Library of functions to create commonly used patterns
+
+Each of the functions takes a `shape` input, which may be a scalar integer or a 2-element Sequence of integers
+indicating the size (shape) in pixels of the returned field. If `shape` is a scalar, the same value is
+used for both axes.
+
+For the coordinates, the OpenGL convention is used, where the coordinates indicate the centers of the pixels.
+By default, the returned pattern is assumed to cover a -1,1 x -1,1 square, 
+which corresponds to a default `extent` parameter of (2.0, 2.0).
+In this case, the coordinates range from -1+dx/2 to 1-dx/2, where dx=2.0/shape is the pixel size.
+
+Exptent and shape may be specified individually to work with anisotropic pixels or rectangular patterns.
+For example, a square pattern with anisotropic pixels may be described by shape=(80,100) and extent(2,2)
+whereas shape=(80,100) and extent(8,10) describes square pixels that form a rectangle.
+
+In a pupil-conjugate configuration, a disk of extent=(NA, NA) exactly covers the back pupil of the microscope objective.
+The transformation matrix of the SLM should be set such that SLM coordinates correspond to normalized pupil coordinates.
+
+The extent may have a unit of measure. In this case, other parameters (such as `radius`) may need to have
+an according unit of measure.
+
+The (0,0) coordinate is always located in the center of the pattern, which may be on a grid point (for odd shape)
+or between grid points (for even shape).
+
+The returned array has a pixel_size property attached.
+"""
+
+
+def tilt(
+    rx,
+    ry,
+    g,
+    phase_offset: float = 0.0,
+):
+    """Constructs a linear gradient pattern φ=2g·r
+
+    Note, these are the Zernike tilt modes (modes 2 and 3 in the Noll index convention) with normalization
+    so that :math:`\\frac{\\int_0^{2\\pi} \\int_0^1 |Z(\\rho, \\phi)|^2 \\rho d\\rho d\\phi}{\\int_0^{2\\pi} \\int_0^1 \\rho d\\rho d\\phi} = 1`.
+
+    Args:
+        rx: array of the pupil plane coordinates in the x-direction. The shape of rx and ry should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
+        ry: array of the pupil plane coordinates in the y-direction. The shape of rx and ry should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
+        g(tuple of two floats): gradient vector.
+            When used in the pupil plane of an objective, this patterns causes a displacement of the beam along the x and y dimensions. For rx and ry in pupil coordinates (i.e. -1 to 1), this patterns causes a displacement of: (gx, gy) * (-2 /π * λ / 2 / numerical_aperturn).
+          (Note: a positive x-gradient g causes the focal point to move in the _negative_ x-direction)
+        phase_offset: optional additional phase offset to be added to the pattern
+
+    Return:
+        An array of the same shape as rx and ry (or broadcasted), containing the phase values of the tilt pattern.
+    """
+    return unitless(rx * 2 * g[0] + ry * 2 * g[1] + phase_offset)
+
+
+def lens(rx, ry, f, wavelength, numerical_aperture):
+    """Constructs a square texture that represents a wavefront defocus: (f-sqrt(f²+r²)) · 2π/λ
+
+    Args:
+        rx: array of the pupil plane coordinates in the x-direction. The shape of rx and ry should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
+        ry: array of the pupil plane coordinates in the y-direction. The shape of rx and ry should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
+        f: focal length of the lens.
+        wavelength: wavelength of the light.
+        numerical_aperture: numerical aperture of the lens. This is used to convert the pupil-conjugate coordinates rx and ry to physical units (i.e. to convert from pupil coordinates to k-space coordinates). An rx and ry of 1 correspond to the edge of the pupil, convering the full numerical aperture of the lens (applied by the phase mask).
+
+    Return:
+        An array of the same shape as rx and ry (or broadcasted), containing the phase values of the lens pattern.
+    """
+    k = 2 * np.pi / wavelength
+    return unitless(k * f * (1 - np.sqrt(1 + (rx**2 + ry**2) * numerical_aperture**2)))
+
+
+def propagation(
+    rx,
+    ry,
+    distance: ScalarType,
+    wavelength: ScalarType,
+    refractive_index: ScalarType,
+    numerical_aperture: ScalarType,
+):
+    """
+    Computes the phase mask that can be applied in the pupil plane of an objective to digitially propagate the field in the object plane by a distance `distance`.
+
+    Args:
+        rx: array of the pupil plane coordinates in the x-direction. The shape of rx and ry should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
+        ry: array of the pupil plane coordinates in the y-direction. The shape of rx and ry should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
+        distance (ScalarType): physical distance to propagate axially.
+        refractive_index (Scalar): refractive index of the medium in which the light is propagating.
+        wavelength (Scalar): wavelength of the light.
+        numerical_aperture: numerical aperture of the lens. This is used to convert the pupil-conjugate coordinates rx and ry to physical units (i.e. to convert from pupil coordinates to k-space coordinates). An rx and ry of 1 correspond to the edge of the pupil, convering the full numerical aperture of the lens (applied by the phase mask).
+    """
+    k = 2 * np.pi * refractive_index / wavelength
+    k_x = k * numerical_aperture * rx
+    k_y = k * numerical_aperture * ry
+    k_z = np.sqrt(k**2 - k_x**2 - k_y**2)
+
+    return unitless(distance * k_z)
+
+
+def disk(
+    rx,
+    ry,
+    radius: ScalarType,
+):
+    """Constructs an image of a centered (ellipsoid) disk.
+
+    (rx)^2 + (ry)^2 <= radius^2
+
+    Args:
+    """
+    return (rx**2 + ry**2) <= radius**2
+
+
+def gaussian(
+    rx,
+    ry,
+    waist: ScalarType,
+    truncation_radius: ScalarType = None,
+):
+    """Constructs an image of a centered Gaussian
+
+    `waist`, `extent` and the optional `truncation_radius` should all have the same unit.
+
+    Args:
+        waist (ScalarType): location of the beam waist (1/e value)
+            relative to half of the size of the pattern (i.e. relative to the `radius` of the square)
+        truncation_radius (ScalarType): when not None, specifies the radius of a disk that is used to truncate the
+            Gaussian. All values outside the disk are set to 0.
+        extent: see module documentation
+        offset: offsets the centre of the Gaussian. The centre of the disk is also offsetted by this amount.
+
+    """
+    w2inv = -1.0 / waist**2
+    gauss = np.exp(unitless((rx**2 + ry**2) * w2inv))
+    if truncation_radius is not None:
+        gauss = gauss * disk(rx, ry, truncation_radius)
+    return unitless(gauss)

--- a/openwfs/utilities/patterns_f.py
+++ b/openwfs/utilities/patterns_f.py
@@ -14,7 +14,8 @@ ScalarType = Union[float, np.ndarray, Quantity]
 def tilt(
     x,
     y,
-    g,
+    gx,
+    gy,
     phase_offset: float = 0.0,
 ):
     """Constructs a linear gradient pattern φ=2g·r
@@ -33,7 +34,7 @@ def tilt(
     Return:
         An array of the same shape as x and y (or broadcasted), containing the phase values of the tilt pattern.
     """
-    return unitless(x * 2 * g[0] + y * 2 * g[1] + phase_offset)
+    return unitless(x * 2 * gx + y * 2 * gy + phase_offset)
 
 
 def lens(x, y, f, wavelength, numerical_aperture):
@@ -58,8 +59,8 @@ def propagation(
     y,
     distance: Quantity,
     wavelength: Quantity,
-    refractive_index: ScalarType,
     numerical_aperture: ScalarType,
+    refractive_index: ScalarType = 1.0,
 ):
     """
     Computes the phase mask that can be applied in the pupil plane of an objective to digitially propagate the field in the object plane by a distance `distance`.
@@ -83,7 +84,7 @@ def propagation(
 def disk(
     x,
     y,
-    radius: ScalarType,
+    radius: float,
 ):
     """Constructs an image of a centered (ellipsoid) disk.
 

--- a/openwfs/utilities/patterns_f.py
+++ b/openwfs/utilities/patterns_f.py
@@ -1,5 +1,5 @@
 from typing import Union, Sequence, Optional
-from .utilities import ExtentType, CoordinateType, unitless
+from .utilities import ExtentType, unitless
 
 import numpy as np
 from astropy.units import Quantity

--- a/openwfs/utilities/patterns_f.py
+++ b/openwfs/utilities/patterns_f.py
@@ -118,3 +118,21 @@ def gaussian(
     if truncation_radius is not None:
         gauss = gauss * disk(x, y, truncation_radius)
     return unitless(gauss)
+
+
+def parabolic(
+    x,
+    y,
+    parabolic_coef: ScalarType,
+):
+    """Constructs a parabolic phase mask: φ = parabolic_coef * (x² + y²)
+
+    Args:
+        x: array of the pupil plane coordinates in the x-direction. The shape of x and y should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
+        y: array of the pupil plane coordinates in the y-direction. The shape of x and y should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
+        parabolic_coef (ScalarType): coefficient of the parabolic phase mask.
+
+    Return:
+        An array of the same shape as x and y (or broadcasted), containing the phase values of the parabolic pattern.
+    """
+    return unitless(parabolic_coef * (x**2 + y**2))

--- a/openwfs/utilities/patterns_f.py
+++ b/openwfs/utilities/patterns_f.py
@@ -120,19 +120,19 @@ def gaussian(
     return unitless(gauss)
 
 
-def parabolic(
+def parabola(
     x,
     y,
-    parabolic_coef: ScalarType,
+    alpha: ScalarType,
 ):
-    """Constructs a parabolic phase mask: φ = parabolic_coef * (x² + y²)
+    """Constructs a parabola phase mask: φ = alpha * (x² + y²)
 
     Args:
         x: array of the pupil plane coordinates in the x-direction. The shape of x and y should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
         y: array of the pupil plane coordinates in the y-direction. The shape of x and y should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
-        parabolic_coef (ScalarType): coefficient of the parabolic phase mask.
+        alpha (ScalarType): coefficient of the parabola phase mask.
 
     Return:
-        An array of the same shape as x and y (or broadcasted), containing the phase values of the parabolic pattern.
+        An array of the same shape as x and y (or broadcasted), containing the phase values of the parabola pattern.
     """
-    return unitless(parabolic_coef * (x**2 + y**2))
+    return unitless(alpha * (x**2 + y**2))

--- a/openwfs/utilities/patterns_f.py
+++ b/openwfs/utilities/patterns_f.py
@@ -10,38 +10,10 @@ ShapeType = Union[int, Sequence[int]]
 # a scalar quantity with optional unit attached
 ScalarType = Union[float, np.ndarray, Quantity]
 
-"""
-Library of functions to create commonly used patterns
-
-Each of the functions takes a `shape` input, which may be a scalar integer or a 2-element Sequence of integers
-indicating the size (shape) in pixels of the returned field. If `shape` is a scalar, the same value is
-used for both axes.
-
-For the coordinates, the OpenGL convention is used, where the coordinates indicate the centers of the pixels.
-By default, the returned pattern is assumed to cover a -1,1 x -1,1 square, 
-which corresponds to a default `extent` parameter of (2.0, 2.0).
-In this case, the coordinates range from -1+dx/2 to 1-dx/2, where dx=2.0/shape is the pixel size.
-
-Exptent and shape may be specified individually to work with anisotropic pixels or rectangular patterns.
-For example, a square pattern with anisotropic pixels may be described by shape=(80,100) and extent(2,2)
-whereas shape=(80,100) and extent(8,10) describes square pixels that form a rectangle.
-
-In a pupil-conjugate configuration, a disk of extent=(NA, NA) exactly covers the back pupil of the microscope objective.
-The transformation matrix of the SLM should be set such that SLM coordinates correspond to normalized pupil coordinates.
-
-The extent may have a unit of measure. In this case, other parameters (such as `radius`) may need to have
-an according unit of measure.
-
-The (0,0) coordinate is always located in the center of the pattern, which may be on a grid point (for odd shape)
-or between grid points (for even shape).
-
-The returned array has a pixel_size property attached.
-"""
-
 
 def tilt(
-    rx,
-    ry,
+    x,
+    y,
     g,
     phase_offset: float = 0.0,
 ):
@@ -51,39 +23,39 @@ def tilt(
     so that :math:`\\frac{\\int_0^{2\\pi} \\int_0^1 |Z(\\rho, \\phi)|^2 \\rho d\\rho d\\phi}{\\int_0^{2\\pi} \\int_0^1 \\rho d\\rho d\\phi} = 1`.
 
     Args:
-        rx: array of the pupil plane coordinates in the x-direction. The shape of rx and ry should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
-        ry: array of the pupil plane coordinates in the y-direction. The shape of rx and ry should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
+        x: array of the pupil plane coordinates in the x-direction. The shape of x and y should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
+        y: array of the pupil plane coordinates in the y-direction. The shape of x and y should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
         g(tuple of two floats): gradient vector.
-            When used in the pupil plane of an objective, this patterns causes a displacement of the beam along the x and y dimensions. For rx and ry in pupil coordinates (i.e. -1 to 1), this patterns causes a displacement of: (gx, gy) * (-2 /π * λ / 2 / numerical_aperturn).
+            When used in the pupil plane of an objective, this patterns causes a displacement of the beam along the x and y dimensions. For x and y in normalised pupil coodinates (i.e. -1 to 1), this patterns causes a displacement of: (gx, gy) * (-2 /π * λ / 2 / numerical_aperturn).
           (Note: a positive x-gradient g causes the focal point to move in the _negative_ x-direction)
         phase_offset: optional additional phase offset to be added to the pattern
 
     Return:
-        An array of the same shape as rx and ry (or broadcasted), containing the phase values of the tilt pattern.
+        An array of the same shape as x and y (or broadcasted), containing the phase values of the tilt pattern.
     """
-    return unitless(rx * 2 * g[0] + ry * 2 * g[1] + phase_offset)
+    return unitless(x * 2 * g[0] + y * 2 * g[1] + phase_offset)
 
 
-def lens(rx, ry, f, wavelength, numerical_aperture):
+def lens(x, y, f, wavelength, numerical_aperture):
     """Constructs a square texture that represents a wavefront defocus: (f-sqrt(f²+r²)) · 2π/λ
 
     Args:
-        rx: array of the pupil plane coordinates in the x-direction. The shape of rx and ry should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
-        ry: array of the pupil plane coordinates in the y-direction. The shape of rx and ry should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
+        x: array of the normalised pupil plane coordinates in the x-direction. The shape of x and y should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
+        y: array of the normalised pupil plane coordinates in the y-direction. The shape of x and y should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
         f: focal length of the lens.
         wavelength: wavelength of the light.
-        numerical_aperture: numerical aperture of the lens. This is used to convert the pupil-conjugate coordinates rx and ry to physical units (i.e. to convert from pupil coordinates to k-space coordinates). An rx and ry of 1 correspond to the edge of the pupil, convering the full numerical aperture of the lens (applied by the phase mask).
+        numerical_aperture: numerical aperture of the lens. This is used to convert the pupil-conjugate coordinates x and y to physical units (i.e. to convert from normalised pupil coodinates to k-space coordinates). An x and y of 1 correspond to the edge of the pupil, convering the full numerical aperture of the lens (applied by the phase mask).
 
     Return:
-        An array of the same shape as rx and ry (or broadcasted), containing the phase values of the lens pattern.
+        An array of the same shape as x and y (or broadcasted), containing the phase values of the lens pattern.
     """
     k = 2 * np.pi / wavelength
-    return unitless(k * f * (1 - np.sqrt(1 + (rx**2 + ry**2) * numerical_aperture**2)))
+    return unitless(k * f * (1 - np.sqrt(1 + (x**2 + y**2) * numerical_aperture**2)))
 
 
 def propagation(
-    rx,
-    ry,
+    x,
+    y,
     distance: ScalarType,
     wavelength: ScalarType,
     refractive_index: ScalarType,
@@ -93,38 +65,38 @@ def propagation(
     Computes the phase mask that can be applied in the pupil plane of an objective to digitially propagate the field in the object plane by a distance `distance`.
 
     Args:
-        rx: array of the pupil plane coordinates in the x-direction. The shape of rx and ry should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
-        ry: array of the pupil plane coordinates in the y-direction. The shape of rx and ry should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
+        x: array of the pupil plane coordinates in the x-direction. The shape of x and y should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
+        y: array of the pupil plane coordinates in the y-direction. The shape of x and y should be such that they can be added together (i.e. they should be the same shape, or one of them should be broadcastable to the shape of the other).
         distance (ScalarType): physical distance to propagate axially.
         refractive_index (Scalar): refractive index of the medium in which the light is propagating.
         wavelength (Scalar): wavelength of the light.
-        numerical_aperture: numerical aperture of the lens. This is used to convert the pupil-conjugate coordinates rx and ry to physical units (i.e. to convert from pupil coordinates to k-space coordinates). An rx and ry of 1 correspond to the edge of the pupil, convering the full numerical aperture of the lens (applied by the phase mask).
+        numerical_aperture: numerical aperture of the lens. This is used to convert the pupil-conjugate coordinates x and y to physical units (i.e. to convert from normalised pupil coodinates to k-space coordinates). An x and y of 1 correspond to the edge of the pupil, convering the full numerical aperture of the lens (applied by the phase mask).
     """
     k = 2 * np.pi * refractive_index / wavelength
-    k_x = k * numerical_aperture * rx
-    k_y = k * numerical_aperture * ry
+    k_x = k * numerical_aperture * x
+    k_y = k * numerical_aperture * y
     k_z = np.sqrt(np.maximum(k**2 - k_x**2 - k_y**2, 0))
 
     return unitless(distance * k_z)
 
 
 def disk(
-    rx,
-    ry,
+    x,
+    y,
     radius: ScalarType,
 ):
     """Constructs an image of a centered (ellipsoid) disk.
 
-    (rx)^2 + (ry)^2 <= radius^2
+    (x)^2 + (y)^2 <= radius^2
 
     Args:
     """
-    return (rx**2 + ry**2) <= radius**2
+    return (x**2 + y**2) <= radius**2
 
 
 def gaussian(
-    rx,
-    ry,
+    x,
+    y,
     waist: ScalarType,
     truncation_radius: ScalarType = None,
 ):
@@ -142,7 +114,7 @@ def gaussian(
 
     """
     w2inv = -1.0 / waist**2
-    gauss = np.exp(unitless((rx**2 + ry**2) * w2inv))
+    gauss = np.exp(unitless((x**2 + y**2) * w2inv))
     if truncation_radius is not None:
-        gauss = gauss * disk(rx, ry, truncation_radius)
+        gauss = gauss * disk(x, y, truncation_radius)
     return unitless(gauss)

--- a/openwfs/utilities/tests.py
+++ b/openwfs/utilities/tests.py
@@ -2,15 +2,36 @@ import numpy as np
 import astropy.units as u
 
 
-def get_test_microscope():
+def get_test_microscope(
+    slm_args={},
+    src_args={},
+    mic_args={},
+):
     """
-    Convenience function returning a basic microscope (simulation) setup for testing purposes. The microscope has a static source representing a point source, and an SLM as incident field. The microscope parameters are:
+    Convenience function returning a basic microscope (simulation) setup for testing purposes. The microscope has a static source representing a point source, and an SLM as incident field. The default settings are:
     - Specimen resolution: (512, 512) pixels
     - Specimen pixel size: 100 nm
     - Numerical aperture: 0.85
     - Wavelength: 532.8 nm
     - Incident field: SLM with shape (512, 512).
+    - Magnification: 1
 
+    Any setting can be customized by passing the desired arguments to the function. The arguments are passed as dictionaries, which are then passed to the respective openwfs function. Three dictionaries can be used as input which control the arguments to the StaticSource, SLM, and Microscope. The keys of the dictionaries are the variable name which are passed to the StaticSource, SLM and Microscope construtor.
+
+    For example, to change the numerical aperture to 0.95, you can call the function as follows:
+    ```python
+    mic, slm, src = get_test_microscope(mic_args={"numerical_aperture": 0.95})
+    mic, slm, src = get_test_microscope(slm_args={"shape": (256, 256)})
+    mic, slm, src = get_test_microscope(src_args={"pixel_size": 50 * u.nm})
+    ```
+
+    Inputs:
+        slm_args: dict
+            Dictionary containing the arguments for the SLM constructor.
+        src_args: dict
+            Dictionary containing the arguments for the StaticSource constructor.
+        mic_args: dict
+            Dictionary containing the arguments for the Microscope constructor.
     Returns:
         mic: Microscope
             The microscope object.
@@ -21,25 +42,30 @@ def get_test_microscope():
     """
     import openwfs.simulation as owf_s
 
-    specimen_resolution = (512, 512)
-    specimen_pixel_size = 100.0 * u.nm
-    numerical_aperture = 0.85
-    wavelength = 532.8 * u.nm
-    img_plane = np.zeros(specimen_resolution)
-    img_plane[100:102, 400:402] = 1.0
+    default_slm_args = {
+        "shape": (512, 512),
+    }
+    slm_args = default_slm_args | slm_args
 
-    src = owf_s.StaticSource(
-        data=img_plane,
-        pixel_size=specimen_pixel_size,
-    )
+    src_data = np.zeros((512, 512))
+    src_data[256, 256] = 1.0
+    default_src_args = {
+        "data": src_data,
+        "pixel_size": 100 * u.nm,
+    }
+    src_args = default_src_args | src_args
 
-    slm = owf_s.SLM(shape=(512, 512))
+    src = owf_s.StaticSource(**src_args)
 
-    mic = owf_s.Microscope(
-        src,
-        magnification=1.0,
-        numerical_aperture=numerical_aperture,
-        wavelength=wavelength,
-        incident_field=slm.field,
-    )
+    slm = owf_s.SLM(**slm_args)
+
+    default_mic_args = {
+        "magnification": 1,
+        "numerical_aperture": 0.85,
+        "wavelength": 532.8 * u.nm,
+        "incident_field": slm.field,
+    }
+    mic_args = default_mic_args | mic_args
+
+    mic = owf_s.Microscope(src, **mic_args)
     return mic, slm, src

--- a/openwfs/utilities/utilities.py
+++ b/openwfs/utilities/utilities.py
@@ -293,7 +293,7 @@ def project(
     out: Optional[np.ndarray] = None,
     out_extent: Optional[ExtentType] = None,
     out_shape: Optional[tuple[int, ...]] = None,
-    interp = cv2.INTER_NEAREST,
+    interp=cv2.INTER_NEAREST,
 ) -> np.ndarray:
     """Projects the input image onto an array with specified shape and resolution.
 

--- a/openwfs/utilities/utilities.py
+++ b/openwfs/utilities/utilities.py
@@ -431,7 +431,7 @@ def get_extent(data: np.ndarray) -> Quantity:
     """
     pixel_size = get_pixel_size(data)
     if pixel_size is None:
-        raise ValueError("Data does not have pixel size metadata, so extent cannot be computed.")
+        return None
     return data.shape * pixel_size
 
 

--- a/openwfs/utilities/utilities.py
+++ b/openwfs/utilities/utilities.py
@@ -293,6 +293,7 @@ def project(
     out: Optional[np.ndarray] = None,
     out_extent: Optional[ExtentType] = None,
     out_shape: Optional[tuple[int, ...]] = None,
+    interp = cv2.INTER_NEAREST,
 ) -> np.ndarray:
     """Projects the input image onto an array with specified shape and resolution.
 
@@ -312,6 +313,7 @@ def project(
             If not given, the extent metadata of the out image is used.
         out_shape: shape of the output image.
             This value is ignored if `out` is specified.
+        interp: interpolation method to use when rescaling the image. See OpenCV documentation for options.
 
     Returns:
         np.ndarray: the projected image (`out` if specified, otherwise a new array)
@@ -343,7 +345,7 @@ def project(
             source.real,
             t,
             out_size,
-            flags=cv2.INTER_NEAREST,
+            flags=interp,
             borderMode=cv2.BORDER_CONSTANT,
             borderValue=(0.0,),
         )
@@ -352,7 +354,7 @@ def project(
             source.imag,
             t,
             out_size,
-            flags=cv2.INTER_NEAREST,
+            flags=interp,
             borderMode=cv2.BORDER_CONSTANT,
             borderValue=(0.0,),
         )
@@ -363,7 +365,7 @@ def project(
             t,
             out_size,
             dst=out,
-            flags=cv2.INTER_NEAREST,
+            flags=interp,
             borderMode=cv2.BORDER_CONSTANT,
             borderValue=(0.0,),
         )

--- a/openwfs/utilities/utilities.py
+++ b/openwfs/utilities/utilities.py
@@ -431,7 +431,7 @@ def get_extent(data: np.ndarray) -> Quantity:
     """
     pixel_size = get_pixel_size(data)
     if pixel_size is None:
-        return Quantity(data.shape)
+        raise ValueError("Data does not have pixel size metadata, so extent cannot be computed.")
     return data.shape * pixel_size
 
 

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -71,7 +71,7 @@ def test_propagation(extent, refractive_index):
     phi = propagation(shape, extent, d, wavelength, refractive_index, na)
 
     r_r = coordinate_range(shape, extent)[0][0, 0]
-    kr = 2 * np.pi * refractive_index / wavelength * na * r_r
+    kr = 2 * np.pi / wavelength * na * r_r
     kz = np.sqrt((2 * np.pi * refractive_index / wavelength) ** 2 - kr**2)
     ref_value = unitless(d * kz)
 

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,12 +1,11 @@
 import pytest
 import numpy as np
-from openwfs.utilities.patterns import tilt
-from openwfs.utilities.patterns import gaussian, disk
+from openwfs.utilities.patterns import tilt, gaussian, disk
 
 
 @pytest.mark.parametrize("shape", [10, (7, 10)])
 def test_tilt(shape):
-    t = tilt(shape, (5, 0.71))
+    t = tilt(shape, (2, 2), (5, 0.71))
     if np.size(shape) == 1:
         shape = (shape, shape)
 
@@ -19,18 +18,18 @@ def test_tilt(shape):
     assert np.allclose(t[-1, -1] - t[-1, 0], phase_diff1)
 
 
-shape = (101, 66)
-offset = (0.2, 0.3)
-waist = 0.25
-g = gaussian(shape, waist=0.25, offset=offset)
-argmax = np.unravel_index(np.argmax(g), g.shape)
+def test_gaussian_disk_offset():
+    shape = (101, 66)
+    offset = (0.2, 0.3)
+    waist = 0.25
+    g = gaussian(shape, extent=(2, 2), waist=waist, offset=offset)
+    argmax = np.unravel_index(np.argmax(g), g.shape)
 
-# assumes default extent of (2.0, 2.0)
-expected = np.round((np.array(offset) + 1) * (np.array(shape) - 1) / 2.0)
-assert np.allclose(expected, argmax)
+    expected = np.round((np.array(offset) + 1) * (np.array(shape) - 1) / 2.0)
+    assert np.allclose(expected, argmax)
 
-shape = (101, 101)
-d = disk(shape, 2 / 101, offset=offset)
-arg_center = np.argwhere(d > 0.5)[0]
-expected = (np.array(offset) + 1) * (np.array(shape) - 1) / 2.0
-assert np.allclose(expected, arg_center)
+    shape = (101, 101)
+    d = disk(shape, (2, 2), 2 / 101, offset=offset)
+    arg_center = np.argwhere(d > 0.5)[0]
+    expected = (np.array(offset) + 1) * (np.array(shape) - 1) / 2.0
+    assert np.allclose(expected, arg_center)

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from openwfs.utilities.patterns import tilt, gaussian, disk
+from openwfs.utilities.patterns import tilt, gaussian, disk, propagation
 
 
 @pytest.mark.parametrize("shape", [10, (7, 10)])

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,6 +1,8 @@
 import pytest
 import numpy as np
-from openwfs.utilities.patterns import tilt, gaussian, disk, propagation, parabola
+from openwfs.utilities.patterns import tilt, gaussian, disk, propagation, parabola, binary_grating, coordinate_range
+from openwfs.utilities import unitless
+import astropy.units as u
 
 
 @pytest.mark.parametrize("shape", [10, (7, 10)])
@@ -41,3 +43,36 @@ def test_parabola():
     r = -1 + 1 / 11
     assert np.allclose(phi[0, 5], 0.5 * (r**2))
     assert np.allclose(phi[0, 0], 0.5 * (r**2 + r**2))
+
+
+@pytest.mark.parametrize("extent", [2, 4])
+def test_binary_grating(extent):
+    period = 0.1
+    values = (1, 2)
+    shape = (1000, 1)
+    phi = binary_grating(shape, extent, period, values, angle=0)
+    first_up = np.argmax(phi)
+    phi_2 = phi[first_up:]
+    first_down = np.argmin(phi_2)
+    np.allclose(phi_2[0], values[1])
+    np.allclose(phi_2[first_down], values[0])
+    p = first_down
+    np.allclose(phi_2[p : p + first_down], values[0])
+    np.allclose(phi_2[p + first_down : p + 2 * first_down], values[1])
+    np.allclose(period, 2 * p / shape[0] * extent)
+
+
+@pytest.mark.parametrize("extent, refractive_index", [(2, 1.0), (1, 1.5)])
+def test_propagation(extent, refractive_index):
+    shape = 101
+    d = 10 * u.um
+    wavelength = 0.5 * u.um
+    na = 1
+    phi = propagation(shape, extent, d, wavelength, refractive_index, na)
+
+    r_r = coordinate_range(shape, extent)[0][0, 0]
+    kr = 2 * np.pi * refractive_index / wavelength * na * r_r
+    kz = np.sqrt((2 * np.pi * refractive_index / wavelength) ** 2 - kr**2)
+    ref_value = unitless(d * kz)
+
+    assert np.allclose(ref_value, phi[0, 50])

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -7,7 +7,7 @@ import astropy.units as u
 
 @pytest.mark.parametrize("shape", [10, (7, 10)])
 def test_tilt(shape):
-    t = tilt(shape, (2, 2), (5, 0.71))
+    t = tilt(shape, extent=(2, 2), g=(5, 0.71))
     if np.size(shape) == 1:
         shape = (shape, shape)
 
@@ -31,14 +31,14 @@ def test_gaussian_disk_offset():
     assert np.allclose(expected, argmax)
 
     shape = (101, 101)
-    d = disk(shape, (2, 2), 2 / 101, offset=offset)
+    d = disk(shape, radius=2 / 101, extent=(2, 2), offset=offset)
     arg_center = np.argwhere(d > 0.5)[0]
     expected = (np.array(offset) + 1) * (np.array(shape) - 1) / 2.0
     assert np.allclose(expected, arg_center)
 
 
 def test_parabola():
-    phi = parabola((11, 11), (2, 2), 0.5)
+    phi = parabola((11, 11), extent=(2, 2), alpha=0.5)
     assert np.allclose(phi[5, 5], 0)
     r = -1 + 1 / 11
     assert np.allclose(phi[0, 5], 0.5 * (r**2))
@@ -50,7 +50,7 @@ def test_binary_grating(extent):
     period = 0.1
     values = (1, 2)
     shape = (1000, 1)
-    phi = binary_grating(shape, extent, period, values, angle=0)
+    phi = binary_grating(shape, period, values, extent=extent, angle=0)
     first_up = np.argmax(phi)
     phi_2 = phi[first_up:]
     first_down = np.argmin(phi_2)
@@ -68,7 +68,7 @@ def test_propagation(extent, refractive_index):
     d = 10 * u.um
     wavelength = 0.5 * u.um
     na = 1
-    phi = propagation(shape, extent, d, wavelength, refractive_index, na)
+    phi = propagation(shape, d, wavelength, na, refractive_index=refractive_index, extent=extent)
 
     r_r = coordinate_range(shape, extent)[0][0, 0]
     kr = 2 * np.pi / wavelength * na * r_r

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from openwfs.utilities.patterns import tilt, gaussian, disk, propagation
+from openwfs.utilities.patterns import tilt, gaussian, disk, propagation, parabolic
 
 
 @pytest.mark.parametrize("shape", [10, (7, 10)])
@@ -33,3 +33,11 @@ def test_gaussian_disk_offset():
     arg_center = np.argwhere(d > 0.5)[0]
     expected = (np.array(offset) + 1) * (np.array(shape) - 1) / 2.0
     assert np.allclose(expected, arg_center)
+
+
+def test_parabolic():
+    phi = parabolic((11, 11), (2, 2), parabolic_coef=0.5)
+    assert np.allclose(phi[5, 5], 0)
+    r = -1 + 1 / 11
+    assert np.allclose(phi[0, 5], 0.5 * (r**2))
+    assert np.allclose(phi[0, 0], 0.5 * (r**2 + r**2))

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from openwfs.utilities.patterns import tilt, gaussian, disk, propagation, parabolic
+from openwfs.utilities.patterns import tilt, gaussian, disk, propagation, parabola
 
 
 @pytest.mark.parametrize("shape", [10, (7, 10)])
@@ -35,8 +35,8 @@ def test_gaussian_disk_offset():
     assert np.allclose(expected, arg_center)
 
 
-def test_parabolic():
-    phi = parabolic((11, 11), (2, 2), parabolic_coef=0.5)
+def test_parabola():
+    phi = parabola((11, 11), (2, 2), 0.5)
     assert np.allclose(phi[5, 5], 0)
     r = -1 + 1 / 11
     assert np.allclose(phi[0, 5], 0.5 * (r**2))

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -259,7 +259,8 @@ def test_mock_slm_lut_and_phase_response():
     assert np.all(np.abs(slm4.phases.read()[0] - linear_phase_highres) < (3 * np.pi / 256))
 
 
-def test_parabola_shift():
+@pytest.mark.parametrize("extent", [2, 4])
+def test_parabola_shift(extent):
     """
     Tests that a display of a parabola pattern on the SLM with an certain offset results in the expected shift in the image plane.
     """
@@ -272,15 +273,15 @@ def test_parabola_shift():
     pupil_offset = (
         np.multiply(np.multiply(offset_focal, mic.numerical_aperture), -np.pi / mic.wavelength) / coef_parabola
     )
-    phi = parabola((1024, 1024), (2, 2), coef_parabola)
+    phi = parabola((1024, 1024), extent, coef_parabola)
     slm.set_phases(phi)
+    mic.slm_transform = Transform(np.eye(2) * extent / 2, np.zeros(2), np.zeros(2))
     img_1 = mic.read()
 
-    phi = parabola((1024, 1024), (2, 2), coef_parabola, offset=pupil_offset)
+    phi = parabola((1024, 1024), extent, coef_parabola, offset=pupil_offset)
     slm.set_phases(phi)
     img_2 = mic.read()
     measured_shift = shift_between_img_max(img_1, img_2) * get_pixel_size(img_1)
-    print(measured_shift)
     assert np.allclose(measured_shift, offset_focal)
 
 

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -286,14 +286,13 @@ def test_parabola_shift(extent):
 
 
 @pytest.mark.parametrize("extent", [2, 4])
-def test_parabola(extent):
-    # Test that the parabola pattern produces the expected shift in the image plane if the parabola is not centered on the back pupil plane of the image.
+def test_binary_gratting(extent):
+    # Test that the binary_grating pattern produces the expected shift in the image plane
     na = 0.9
     wav = 500 * u.nm
     mic, slm, src = get_test_microscope(
         mic_args={"numerical_aperture": na, "wavelength": wav}, src_args={"pixel_size": 50 * u.nm}
     )
-    extent = 6
     desired_shift = 1000 * u.nm
     periodicity = mic.wavelength / desired_shift / mic.numerical_aperture
 

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -113,36 +113,19 @@ def test_slm_tilt():
     Display a tilt on the SLM should result in an image plane shift. If the magnification is 1, this should
     correspond to a tilt of 1 pixel for a 2 pi phase shift.
     """
-    img = np.zeros((1000, 1000), dtype=np.int16)
-    signal_location = (256, 250)
-    img[signal_location] = 100
-    pixel_size = 400 * u.nm
-    wavelength = 750 * u.nm
-    src = Camera(StaticSource(img, pixel_size=pixel_size), analog_max=None)
+    mic, slm, src = get_test_microscope(mic_args={"numerical_aperture": 0.5})
 
-    slm = SLM(shape=(1000, 1000))
+    ref_img = mic.read()
+    shift = np.multiply(get_pixel_size(ref_img), (10, -5))
+    gradient = shift * np.pi * 2 * mic.numerical_aperture / mic.wavelength / 2
+    tilt_pattern = tilt(slm.pixels.data_shape, extent=(2, 2), g=gradient)
+    slm.set_phases(tilt_pattern)
 
-    na = 1.0
-    sim = Microscope(
-        source=src,
-        incident_field=slm.field,
-        magnification=1,
-        numerical_aperture=na,
-        wavelength=wavelength,
+    shifted_img = mic.read()
+    measured_shift = np.subtract(
+        np.unravel_index(np.argmax(ref_img), ref_img.shape), np.unravel_index(np.argmax(shifted_img), shifted_img.shape)
     )
-
-    # introduce a tilted pupil plane
-    # the input parameter to `tilt` corresponds to a shift 2.0/π the Abbe diffraction limit.
-    shift = np.array((-24, 40))
-    step = wavelength / (np.pi * na)
-    slm.set_phases(tilt(1000, 2, -shift * pixel_size / step))
-
-    new_location = signal_location + shift
-
-    cam = Camera(sim, analog_max=None)
-    img = cam.read(immediate=True)
-    max_pos = np.unravel_index(np.argmax(img), img.shape)
-    assert np.all(max_pos == new_location)
+    assert np.allclose(np.multiply(get_pixel_size(ref_img), measured_shift), shift)
 
 
 def test_microscope_wavefront_shaping(caplog):
@@ -270,22 +253,3 @@ def test_mock_slm_lut_and_phase_response():
     slm4.lookup_table = lookup_table
     slm4.set_phases(linear_phase_highres)
     assert np.all(np.abs(slm4.phases.read()[0] - linear_phase_highres) < (3 * np.pi / 256))
-
-
-def test_slm_tilt_and_microscope_shift():
-    """
-    Displaying a tilt pattern on the SLM should result in a shift in the image plane. This test checks if the shift is correct.
-    """
-    mic, slm, src = get_test_microscope()
-
-    ref_img = mic.read()
-    shift = np.multiply(get_pixel_size(ref_img), (10, -5))
-    gradient = shift * np.pi * 2 * mic.numerical_aperture / mic.wavelength / 2
-    tilt_pattern = tilt(slm.pixels.data_shape, extent=(2, 2), g=gradient)
-    slm.set_phases(tilt_pattern)
-
-    shifted_img = mic.read()
-    measured_shift = np.subtract(
-        np.unravel_index(np.argmax(ref_img), ref_img.shape), np.unravel_index(np.argmax(shifted_img), shifted_img.shape)
-    )
-    np.allclose(measured_shift, shift)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -286,6 +286,7 @@ def test_parabola_shift():
 
 @pytest.mark.parametrize("extent", [2, 4])
 def test_parabola(extent):
+    # Test that the parabola pattern produces the expected shift in the image plane if the parabola is not centered on the back pupil plane of the image.
     na = 0.9
     wav = 500 * u.nm
     mic, slm, src = get_test_microscope(
@@ -311,6 +312,7 @@ def test_parabola(extent):
 
 
 def test_propagation():
+    # Test that a SLM propagation pattern can compensate for the defocus of the microscope
     mic, slm, src = get_test_microscope()
     img_ref = mic.read()
     phi = propagation(512, 2, 10 * u.um, mic.wavelength, 1, mic.numerical_aperture)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -312,13 +312,24 @@ def test_parabola(extent):
     )
 
 
-def test_propagation():
+@pytest.mark.parametrize("n", [1, 2])
+def test_propagation(n):
     # Test that a SLM propagation pattern can compensate for the defocus of the microscope
-    mic, slm, src = get_test_microscope()
+    mic, slm, src = get_test_microscope(mic_args={"immersion_refractive_index": n})
     img_ref = mic.read()
-    phi = propagation(512, 2, 10 * u.um, mic.wavelength, 1, mic.numerical_aperture)
+    phi = propagation(512, 2, 10 * u.um, mic.wavelength, n, mic.numerical_aperture)
     slm.set_phases(phi)
     mic.z_stage.position = -10 * u.um
     img = mic.read()
 
     assert np.allclose(img, img_ref, atol=1e-3)
+
+
+def test_non_linear_microscope():
+    mic_1, slm_1, src_1 = get_test_microscope()
+    img_ref = mic_1.read()
+
+    mic_2, slm_2, src_2 = get_test_microscope(mic_args={"nonlinearity": 2})
+    img_2p = mic_2.read()
+
+    assert np.allclose(img_2p, img_ref**2)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -9,7 +9,7 @@ from openwfs.algorithms import StepwiseSequential
 from openwfs.processors import SingleRoi
 from openwfs.simulation import Microscope, Camera, StaticSource, SLM
 from openwfs.utilities import get_pixel_size
-from openwfs.utilities.patterns import tilt
+from openwfs.utilities.patterns import tilt, gaussian, parabola
 from openwfs.utilities.tests import get_test_microscope
 
 
@@ -108,6 +108,12 @@ def test_slm_and_aberration():
     assert abs(np.vdot(norm_a, norm_b)) >= 1
 
 
+def shift_between_img_max(ref_img, shifted_img):
+    return np.subtract(
+        np.unravel_index(np.argmax(ref_img), ref_img.shape), np.unravel_index(np.argmax(shifted_img), shifted_img.shape)
+    )
+
+
 def test_slm_tilt():
     """
     Display a tilt on the SLM should result in an image plane shift. If the magnification is 1, this should
@@ -117,14 +123,12 @@ def test_slm_tilt():
 
     ref_img = mic.read()
     shift = np.multiply(get_pixel_size(ref_img), (10, -5))
-    gradient = shift * np.pi * 2 * mic.numerical_aperture / mic.wavelength / 2
+    gradient = shift * np.pi * mic.numerical_aperture / mic.wavelength
     tilt_pattern = tilt(slm.pixels.data_shape, extent=(2, 2), g=gradient)
     slm.set_phases(tilt_pattern)
 
     shifted_img = mic.read()
-    measured_shift = np.subtract(
-        np.unravel_index(np.argmax(ref_img), ref_img.shape), np.unravel_index(np.argmax(shifted_img), shifted_img.shape)
-    )
+    measured_shift = shift_between_img_max(ref_img, shifted_img)
     assert np.allclose(np.multiply(get_pixel_size(ref_img), measured_shift), shift)
 
 
@@ -253,3 +257,26 @@ def test_mock_slm_lut_and_phase_response():
     slm4.lookup_table = lookup_table
     slm4.set_phases(linear_phase_highres)
     assert np.all(np.abs(slm4.phases.read()[0] - linear_phase_highres) < (3 * np.pi / 256))
+
+
+def test_parabola_shift():
+    """
+    Tests that a display of a parabola pattern on the SLM with an certain offset results in the expected shift in the image plane.
+    """
+    offset_focal = np.array([1100, 400]) * u.nm
+    coef_parabola = 0.1
+
+    mic, slm, src = get_test_microscope()
+    pupil_offset = (
+        np.multiply(np.multiply(offset_focal, mic.numerical_aperture), -np.pi / mic.wavelength) / coef_parabola
+    )
+    phi = parabola((1024, 1024), (2, 2), coef_parabola)
+    slm.set_phases(phi)
+    img_1 = mic.read()
+
+    phi = parabola((1024, 1024), (2, 2), coef_parabola, offset=pupil_offset)
+    slm.set_phases(phi)
+    img_2 = mic.read()
+    measured_shift = shift_between_img_max(img_1, img_2) * get_pixel_size(img_1)
+    print(measured_shift)
+    assert np.allclose(measured_shift, offset_focal)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -310,11 +310,12 @@ def test_parabola(extent):
     )
 
 
-mic, slm, src = get_test_microscope()
-extent = 2
-img_ref = mic.read()
-phi = propagation((512, 512), extent, 10 * u.um, mic.wavelength, 1, mic.numerical_aperture)
-slm.set_phases(phi)
-mic.z_stage.position = -10 * u.um
-img = mic.read()
-np.allclose(img, img_ref, atol=1e-3)
+def test_propagation():
+    mic, slm, src = get_test_microscope()
+    img_ref = mic.read()
+    phi = propagation(512, 2, 10 * u.um, mic.wavelength, 1, mic.numerical_aperture)
+    slm.set_phases(phi)
+    mic.z_stage.position = -10 * u.um
+    img = mic.read()
+
+    assert np.allclose(img, img_ref, atol=1e-3)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -8,8 +8,8 @@ import skimage
 from openwfs.algorithms import StepwiseSequential
 from openwfs.processors import SingleRoi
 from openwfs.simulation import Microscope, Camera, StaticSource, SLM
-from openwfs.utilities import get_pixel_size
-from openwfs.utilities.patterns import tilt, gaussian, parabola
+from openwfs.utilities import get_pixel_size, Transform
+from openwfs.utilities.patterns import tilt, gaussian, parabola, binary_grating, propagation
 from openwfs.utilities.tests import get_test_microscope
 
 
@@ -267,6 +267,8 @@ def test_parabola_shift():
     coef_parabola = 0.1
 
     mic, slm, src = get_test_microscope()
+
+    # Pupil shift required to shift the image by offset_focal. See docs of parabola
     pupil_offset = (
         np.multiply(np.multiply(offset_focal, mic.numerical_aperture), -np.pi / mic.wavelength) / coef_parabola
     )
@@ -280,3 +282,39 @@ def test_parabola_shift():
     measured_shift = shift_between_img_max(img_1, img_2) * get_pixel_size(img_1)
     print(measured_shift)
     assert np.allclose(measured_shift, offset_focal)
+
+
+@pytest.mark.parametrize("extent", [2, 4])
+def test_parabola(extent):
+    na = 0.9
+    wav = 500 * u.nm
+    mic, slm, src = get_test_microscope(
+        mic_args={"numerical_aperture": na, "wavelength": wav}, src_args={"pixel_size": 50 * u.nm}
+    )
+    extent = 6
+    desired_shift = 1000 * u.nm
+    periodicity = mic.wavelength / desired_shift / mic.numerical_aperture
+
+    phi = binary_grating((512, 512), extent, periodicity, (0, np.pi), angle=45 * u.deg)
+
+    mic.slm_transform = Transform(np.eye(2) * extent / 2, np.zeros(2), np.zeros(2))
+    slm.set_phases(0)
+    img_ref = mic.read()
+    slm.set_phases(phi)
+    img = mic.read()
+
+    assert np.allclose(
+        np.abs(shift_between_img_max(img_ref, img) * get_pixel_size(img_ref)),
+        np.ones(2) * np.sqrt(2) / 2 * desired_shift.to(u.nm),
+        rtol=0.05,
+    )
+
+
+mic, slm, src = get_test_microscope()
+extent = 2
+img_ref = mic.read()
+phi = propagation((512, 512), extent, 10 * u.um, mic.wavelength, 1, mic.numerical_aperture)
+slm.set_phases(phi)
+mic.z_stage.position = -10 * u.um
+img = mic.read()
+np.allclose(img, img_ref, atol=1e-3)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -297,7 +297,7 @@ def test_parabola(extent):
     desired_shift = 1000 * u.nm
     periodicity = mic.wavelength / desired_shift / mic.numerical_aperture
 
-    phi = binary_grating((512, 512), extent, periodicity, (0, np.pi), angle=45 * u.deg)
+    phi = binary_grating((512, 512), extent=extent, period=periodicity, values=(0, np.pi), angle=45 * u.deg)
 
     mic.slm_transform = Transform(np.eye(2) * extent / 2, np.zeros(2), np.zeros(2))
     slm.set_phases(0)
@@ -317,7 +317,13 @@ def test_propagation(n):
     # Test that a SLM propagation pattern can compensate for the defocus of the microscope
     mic, slm, src = get_test_microscope(mic_args={"immersion_refractive_index": n})
     img_ref = mic.read()
-    phi = propagation(512, 2, 10 * u.um, mic.wavelength, n, mic.numerical_aperture)
+    phi = propagation(
+        512,
+        distance=10 * u.um,
+        wavelength=mic.wavelength,
+        numerical_aperture=mic.numerical_aperture,
+        refractive_index=n,
+    )
     slm.set_phases(phi)
     mic.z_stage.position = -10 * u.um
     img = mic.read()

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -8,7 +8,9 @@ import skimage
 from openwfs.algorithms import StepwiseSequential
 from openwfs.processors import SingleRoi
 from openwfs.simulation import Microscope, Camera, StaticSource, SLM
+from openwfs.utilities import get_pixel_size
 from openwfs.utilities.patterns import tilt
+from openwfs.utilities.tests import get_test_microscope
 
 
 def test_mock_camera_and_single_roi():
@@ -133,7 +135,7 @@ def test_slm_tilt():
     # the input parameter to `tilt` corresponds to a shift 2.0/π the Abbe diffraction limit.
     shift = np.array((-24, 40))
     step = wavelength / (np.pi * na)
-    slm.set_phases(tilt(1000, -shift * pixel_size / step))
+    slm.set_phases(tilt(1000, 2, -shift * pixel_size / step))
 
     new_location = signal_location + shift
 
@@ -268,3 +270,22 @@ def test_mock_slm_lut_and_phase_response():
     slm4.lookup_table = lookup_table
     slm4.set_phases(linear_phase_highres)
     assert np.all(np.abs(slm4.phases.read()[0] - linear_phase_highres) < (3 * np.pi / 256))
+
+
+def test_slm_tilt_and_microscope_shift():
+    """
+    Displaying a tilt pattern on the SLM should result in a shift in the image plane. This test checks if the shift is correct.
+    """
+    mic, slm, src = get_test_microscope()
+
+    ref_img = mic.read()
+    shift = np.multiply(get_pixel_size(ref_img), (10, -5))
+    gradient = shift * np.pi * 2 * mic.numerical_aperture / mic.wavelength / 2
+    tilt_pattern = tilt(slm.pixels.data_shape, extent=(2, 2), g=gradient)
+    slm.set_phases(tilt_pattern)
+
+    shifted_img = mic.read()
+    measured_shift = np.subtract(
+        np.unravel_index(np.argmax(ref_img), ref_img.shape), np.unravel_index(np.argmax(shifted_img), shifted_img.shape)
+    )
+    np.allclose(measured_shift, shift)


### PR DESCRIPTION
Various changes across patterns and microscope to use normalised pupil coordinates everywhere.

List of changes:
- A new namespace was added called patterns_f. This namespace is similar to utilities.patterns but uses the normalised pupil coordinates as input instead of shape and extent. Useful for example when we don't need to work with square phase mask, for example when assuming radial symmetry.
- get_extent returns None instead of shape if no extent is available.
- get_test_microscope accepts dictionaries for fast customization of the testing parameters.
- extent is not an optional input into patterns but a required input.
- patterns all work with normalised pupil coordinates. Because of this, some new input are needed on some patterns function.
- Image calculation of the mock microscope works with normalised pupil coordinates for consistency.
- Update tests of patterns and add new ones
- Add parabola phase mask
- Add binary gratting phase mask
- Add nonlinearity to mock microscope to simulate 2 photon (by Arnon)
- Add immersion medium to mock microscope (by Arnon)