### PR TITLE
Add support for multiple camera

### DIFF
--- a/openwfs/devices/camera.py
+++ b/openwfs/devices/camera.py
@@ -3,10 +3,66 @@ from typing import Optional
 
 import astropy.units as u
 import numpy as np
+import weakref
 from astropy.units import Quantity
 from harvesters.core import Harvester
 
 from ..core import Detector
+
+
+class CameraHarvester:
+    """
+    A wrapper for the Harvester object that allows it to be shared across multiple Camera instances.
+
+    """
+
+    def __init__(self, harvester):
+        self._harvester = harvester
+        self.cti_files = (
+            []
+        )  # Need to keep track of the added CTI files because the same CTI file cannot be added multiple times to the Harvester object. This is a limitation of the Harvesters library, not of this wrapper class. Segmentation fault can occur if the same CTI file is added multiple times.
+
+    def __del__(self):
+        if self._harvester is not None:
+            self._harvester.reset()
+
+    def add_file(self, cti_file):
+        if cti_file not in self.cti_files:
+            try:
+                self._harvester.add_file(cti_file, check_validity=True)
+                self._harvester.update()
+            except (OSError, FileNotFoundError) as e:
+                print(f"Failed to load CTI file: {cti_file}")
+                print(f"Error: {str(e)}")
+                print(
+                    "Please ensure that the CTI file exists at the specified location "
+                    "and that it is a valid GenTL producer file. You can download or "
+                    "locate the file from the camera manufacturer's website or SDK, "
+                    "such as the Basler pylon SDK."
+                )
+            self.cti_files.append(cti_file)
+
+    def enumerate_cameras(self):
+        return self._harvester.device_info_list.copy()
+
+    @staticmethod
+    def get_harvester():
+        """Returns the Harvester object for the specified GenTL producer.
+
+        Returns:
+            Harvester: A Harvester object that can be used to access the cameras available through the specified GenTL producer.
+        """
+        global global_cam_harvester
+        if global_cam_harvester is None:
+            cam_harvester = CameraHarvester(Harvester())
+            global_cam_harvester = weakref.ref(cam_harvester)
+        else:
+            cam_harvester = global_cam_harvester()
+
+        return cam_harvester
+
+
+global_cam_harvester = None
 
 
 class Camera(Detector):
@@ -35,7 +91,7 @@ class Camera(Detector):
         >>> frame = camera.read()
     """
 
-    __slots__ = ("_harvester", "_camera", "_nodes")
+    __slots__ = ("cam_harvester", "_camera", "_nodes")
 
     def __init__(
         self,
@@ -63,29 +119,15 @@ class Camera(Detector):
             **kwargs: Additional keyword arguments.
                 These arguments are transferred to the node map of the camera. They must follow the `genicam` standard.
         """
-        self._harvester = Harvester()
+        global global_cam_harvester
 
-        try:
-            # Try to add the GenTL producer file (cti_file)
-            self._harvester.add_file(cti_file, check_validity=True)
-            print(f"Successfully loaded CTI file: {cti_file}")
-        except Exception as e:
-            # Catch any errors during the file loading process and provide a user-friendly message
-            print(f"Failed to load CTI file: {cti_file}")
-            print(f"Error: {str(e)}")
-            print(
-                "Please ensure that the CTI file exists at the specified location "
-                "and that it is a valid GenTL producer file. You can download or "
-                "locate the file from the camera manufacturer's website or SDK, "
-                "such as the Basler pylon SDK."
-            )
-            raise
-
-        self._harvester.update()
+        self.cam_harvester = CameraHarvester.get_harvester()
+        if cti_file is not None:
+            self.cam_harvester.add_file(cti_file)
 
         # open the camera, use the serial_number to select the camera if it is specified.
         search_key = {"serial_number": serial_number} if serial_number is not None else None
-        self._camera = self._harvester.create(search_key=search_key)
+        self._camera = self.cam_harvester._harvester.create(search_key=search_key)
         nodes = self._camera.remote_device.node_map
         self._nodes = nodes
 
@@ -140,13 +182,15 @@ class Camera(Detector):
         #         automatically expose a selection of properties in the node map as
         #         properties of the Camera object.
         #
-
         try:
             pixel_size = [
                 nodes.SensorPixelHeight.value,
                 nodes.SensorPixelWidth.value,
             ] * u.um
         except AttributeError:  # the SensorPixelWidth feature is optional
+            warnings.warn(
+                "Camera does not have SensorPixelHeight and SensorPixelWidth properties. Pixel size will be set to None. The pixel size can be set manually by setting the _pixel_size attribute of the Camera object, e.g. `camera._pixel_size = [4.8, 4.8] * u.um`"
+            )
             pixel_size = None
 
         super().__init__(
@@ -162,8 +206,6 @@ class Camera(Detector):
         if hasattr(self, "_camera"):
             self._camera.stop()
             self._camera.destroy()
-        if hasattr(self, "_harvester"):
-            self._harvester.reset()
 
     def _do_trigger(self):
         """Executes the software trigger command on the camera.
@@ -310,7 +352,7 @@ class Camera(Detector):
         return self.height, self.width
 
     @staticmethod
-    def enumerate_cameras(cti_file: str):
+    def enumerate_cameras(cti_file=None):
         """Enumerates all cameras available through the specified GenTL producer.
 
         Args:
@@ -322,13 +364,10 @@ class Camera(Detector):
         Warns:
             UserWarning: If the CTI file cannot be loaded.
         """
-        with Harvester() as harvester:
-            try:
-                harvester.add_file(cti_file, check_validity=True)
-                harvester.update()
-            except (OSError, FileNotFoundError):
-                warnings.warn(f"Failed to load CTI file: {cti_file}")
-            return harvester.device_info_list.copy()
+        cam_harvester = CameraHarvester.get_harvester()
+        if cti_file is not None:
+            cam_harvester.add_file(cti_file)
+        return cam_harvester.enumerate_cameras()
 
 
 class _CameraPause:

--- a/openwfs/devices/camera.py
+++ b/openwfs/devices/camera.py
@@ -53,11 +53,15 @@ class CameraHarvester:
             Harvester: A Harvester object that can be used to access the cameras available through the specified GenTL producer.
         """
         global global_cam_harvester
-        if global_cam_harvester is None:
+        if type(global_cam_harvester) is weakref.ReferenceType:
+            if global_cam_harvester() is None:
+                cam_harvester = CameraHarvester(Harvester())
+                global_cam_harvester = weakref.ref(cam_harvester)
+            else:
+                cam_harvester = global_cam_harvester()
+        else:
             cam_harvester = CameraHarvester(Harvester())
             global_cam_harvester = weakref.ref(cam_harvester)
-        else:
-            cam_harvester = global_cam_harvester()
 
         return cam_harvester
 

--- a/openwfs/devices/camera.py
+++ b/openwfs/devices/camera.py
@@ -1,3 +1,4 @@
+import os
 import warnings
 from typing import Optional
 
@@ -5,6 +6,7 @@ import astropy.units as u
 import numpy as np
 from astropy.units import Quantity
 from harvesters.core import Harvester
+from pathlib import Path
 
 from ..core import Detector
 
@@ -39,7 +41,7 @@ class Camera(Detector):
 
     def __init__(
         self,
-        cti_file: str,
+        cti_file: Optional[str] = None,
         serial_number: Optional[str] = None,
         multi_threaded=True,
         **kwargs,
@@ -58,12 +60,24 @@ class Camera(Detector):
                 For Basler cameras, this is typically located in
                 R"C:\\Program Files\\Basler\\pylon 7\\Runtime\\x64\\ProducerU3V.cti".
 
+                If cti_file is NONE (default), the constructor will attempt to find the CTI file in the directory 
+                specified by the `GENICAM_GENTL64_PATH` environment variable. If the environment variable is not 
+                set, a ValueError is raised.
+
             serial_number: The serial number of the camera.
                 When omitted, the first camera found is selected.
             **kwargs: Additional keyword arguments.
                 These arguments are transferred to the node map of the camera. They must follow the `genicam` standard.
         """
         self._harvester = Harvester()
+
+        if cti_file is None:
+            gentl_path = os.environ.get("GENICAM_GENTL64_PATH")
+        if gentl_path:
+            cti_file = str(Path(gentl_path) / "ProducerU3V.cti")
+            print(f"Using GenICam producer: {cti_file}")
+        else:
+            raise ValueError("GENICAM_GENTL64_PATH is not set. Is Basler Pylon installed?")
 
         try:
             # Try to add the GenTL producer file (cti_file)

--- a/openwfs/devices/camera.py
+++ b/openwfs/devices/camera.py
@@ -144,8 +144,6 @@ class Camera(Detector):
             cti_files = [cti_file]
 
         self.cam_harvester = CameraHarvester.get_harvester()
-        if cti_file is not None:
-            self.cam_harvester.add_file(cti_file)
 
         # load all cti files in the harvester
         for cti_file in cti_files:

--- a/openwfs/devices/camera.py
+++ b/openwfs/devices/camera.py
@@ -36,7 +36,7 @@ class CameraHarvester:
                 self._harvester.update()
                 logging.info(f"Successfully loaded CTI file: {cti_file}")
             except (OSError, FileNotFoundError) as e:
-                raise RunTimeError(
+                raise RuntimeError(
                     f"Failed to load CTI file: {cti_file}. Error: {str(e)}\n Please ensure that the CTI file exists at the specified location\nand that it is a valid GenTL producer file. You can download or\nlocate the file from the camera manufacturer's website or SDK,\nsuch as the Basler pylon SDK."
                 )
             self.cti_files.append(cti_file)

--- a/openwfs/devices/camera.py
+++ b/openwfs/devices/camera.py
@@ -77,8 +77,7 @@ class CameraHarvester:
 
         return self._harvester.device_info_list.copy()
 
-    @staticmethod
-    def add_cti_files_enviroment_variable():
+    def add_cti_files_enviroment_variable(self):
         """
         Add all CTI files in the directory specified by the GENICAM_GENTL64_PATH or GENICAM_GENTL32_PATH environment variable to the harvester.
 
@@ -94,11 +93,9 @@ class CameraHarvester:
         # find all cti files in the gentl_path directory and add them to the harvester
         cti_files = [str(p) for gp in gentl_path.split(os.pathsep) for p in Path(gp).glob("*.cti")]
 
-        harvester = CameraHarvester.get_harvester()
-
         # load all cti files in the harvester
         for cti_file in cti_files:
-            harvester.add_file(cti_file)
+            self.add_file(cti_file)
 
 
 global_cam_harvester = None
@@ -164,12 +161,12 @@ class Camera(Detector):
         """
         global global_cam_harvester
 
-        if cti_file is None:
-            CameraHarvester.add_cti_files_enviroment_variable()
-        else:  # if cti_file is provided, use it directly
-            cti_files = [cti_file]
-
         self.cam_harvester = CameraHarvester.get_harvester()
+        if cti_file is None:
+            self.cam_harvester.add_cti_files_enviroment_variable()
+        else:  # if cti_file is provided, use it directly
+            self.cam_harvester.add_file(cti_file)
+
 
         # open the camera, use the serial_number to select the camera if it is specified.
         search_key = {"serial_number": serial_number} if serial_number is not None else None
@@ -396,6 +393,19 @@ class Camera(Detector):
     def data_shape(self):
         """Shape (height, width) of the data array returned by the camera."""
         return self.height, self.width
+
+    @staticmethod
+    def enumerate_cameras(cti_file=None):
+        """Enumerates all cameras available through the specified GenTL producer.
+
+        Args:
+            cti_file: The path to the GenTL producer file. If None, the files on the GENICAM_GENTL64_PATH or GENICAM_GENTL32_PATH environment variable will be used.
+
+        Returns:
+            list: A list of device information dictionaries for all available cameras.
+        """
+        cam_harvester = CameraHarvester.get_harvester()
+        return cam_harvester.enumerate_cameras(cti_file=cti_file)
 
 
 class _CameraPause:

--- a/openwfs/devices/camera.py
+++ b/openwfs/devices/camera.py
@@ -72,18 +72,20 @@ class Camera(Detector):
         self._harvester = Harvester()
 
         if cti_file is None:
-            # for windows use the GENICAM_GENTL64_PATH environment variable, which is set by the Basler pylon installer 
+            # for windows use the GENICAM_GENTL64_PATH environment variable, which is set by the Basler pylon installer
             # by default. Else use the GENICAM_GENTL32_PATH environment variable for 32 bit systems. If neither is set, raise an error.
-            gentl_path = (os.environ.get("GENICAM_GENTL64_PATH") or os.environ.get("GENICAM_GENTL32_PATH"))
+            gentl_path = os.environ.get("GENICAM_GENTL64_PATH") or os.environ.get("GENICAM_GENTL32_PATH")
             if not gentl_path:
-                raise ValueError("GENICAM_GENTL64_PATH and GENICAM_GENTL32_PATH are not set. Check if Basler Pylon is installed or set cti_path manually.")
+                raise ValueError(
+                    "GENICAM_GENTL64_PATH and GENICAM_GENTL32_PATH are not set. Check if Basler Pylon is installed or set cti_path manually."
+                )
             # find all cti files in the gentl_path directory and add them to the harvester
             cti_files = [str(p) for p in Path(gentl_path).glob("*.cti")]
-        else:    # if cti_file is provided, use it directly       
+        else:  # if cti_file is provided, use it directly
             cti_files = [cti_file]
 
         # load all cti files in the harvester
-        for cti_file in cti_files: 
+        for cti_file in cti_files:
             try:
                 # Try to add the GenTL producer file (cti_file)
                 self._harvester.add_file(cti_file, check_validity=True)

--- a/openwfs/devices/camera.py
+++ b/openwfs/devices/camera.py
@@ -61,7 +61,7 @@ class Camera(Detector):
                 R"C:\\Program Files\\Basler\\pylon 7\\Runtime\\x64\\ProducerU3V.cti".
 
                 If cti_file is NONE (default), the constructor will attempt to find the CTI file in the directory
-                specified by the `GENICAM_GENTL64_PATH` environment variable. If the environment variable is not
+                specified by the `GENICAM_GENTL64_PATH` or `GENICAM_GENTL32_PATH` environment variable. If the environment variable is not
                 set, a ValueError is raised.
 
             serial_number: The serial number of the camera.
@@ -72,28 +72,33 @@ class Camera(Detector):
         self._harvester = Harvester()
 
         if cti_file is None:
-            gentl_path = os.environ.get("GENICAM_GENTL64_PATH")
-        if gentl_path:
-            cti_file = str(Path(gentl_path) / "ProducerU3V.cti")
-            print(f"Using GenICam producer: {cti_file}")
-        else:
-            raise ValueError("GENICAM_GENTL64_PATH is not set. Is Basler Pylon installed?")
+            # for windows use the GENICAM_GENTL64_PATH environment variable, which is set by the Basler pylon installer 
+            # by default. Else use the GENICAM_GENTL32_PATH environment variable for 32 bit systems. If neither is set, raise an error.
+            gentl_path = (os.environ.get("GENICAM_GENTL64_PATH") or os.environ.get("GENICAM_GENTL32_PATH"))
+            if not gentl_path:
+                raise ValueError("GENICAM_GENTL64_PATH and GENICAM_GENTL32_PATH are not set. Check if Basler Pylon is installed or set cti_path manually.")
+            # find all cti files in the gentl_path directory and add them to the harvester
+            cti_files = [str(p) for p in Path(gentl_path).glob("*.cti")]
+        else:    # if cti_file is provided, use it directly       
+            cti_files = [cti_file]
 
-        try:
-            # Try to add the GenTL producer file (cti_file)
-            self._harvester.add_file(cti_file, check_validity=True)
-            print(f"Successfully loaded CTI file: {cti_file}")
-        except Exception as e:
-            # Catch any errors during the file loading process and provide a user-friendly message
-            print(f"Failed to load CTI file: {cti_file}")
-            print(f"Error: {str(e)}")
-            print(
-                "Please ensure that the CTI file exists at the specified location "
-                "and that it is a valid GenTL producer file. You can download or "
-                "locate the file from the camera manufacturer's website or SDK, "
-                "such as the Basler pylon SDK."
-            )
-            raise
+        # load all cti files in the harvester
+        for cti_file in cti_files: 
+            try:
+                # Try to add the GenTL producer file (cti_file)
+                self._harvester.add_file(cti_file, check_validity=True)
+                print(f"Successfully loaded CTI file: {cti_file}")
+            except Exception as e:
+                # Catch any errors during the file loading process and provide a user-friendly message
+                print(f"Failed to load CTI file: {cti_file}")
+                print(f"Error: {str(e)}")
+                print(
+                    "Please ensure that the CTI file exists at the specified location "
+                    "and that it is a valid GenTL producer file. You can download or "
+                    "locate the file from the camera manufacturer's website or SDK, "
+                    "such as the Basler pylon SDK."
+                )
+                raise
 
         self._harvester.update()
 

--- a/openwfs/devices/camera.py
+++ b/openwfs/devices/camera.py
@@ -165,7 +165,6 @@ class Camera(Detector):
         else:  # if cti_file is provided, use it directly
             self.cam_harvester.add_file(cti_file)
 
-
         # open the camera, use the serial_number to select the camera if it is specified.
         search_key = {"serial_number": serial_number} if serial_number is not None else None
         self._camera = self.cam_harvester._harvester.create(search_key=search_key)

--- a/openwfs/devices/camera.py
+++ b/openwfs/devices/camera.py
@@ -60,8 +60,8 @@ class Camera(Detector):
                 For Basler cameras, this is typically located in
                 R"C:\\Program Files\\Basler\\pylon 7\\Runtime\\x64\\ProducerU3V.cti".
 
-                If cti_file is NONE (default), the constructor will attempt to find the CTI file in the directory 
-                specified by the `GENICAM_GENTL64_PATH` environment variable. If the environment variable is not 
+                If cti_file is NONE (default), the constructor will attempt to find the CTI file in the directory
+                specified by the `GENICAM_GENTL64_PATH` environment variable. If the environment variable is not
                 set, a ValueError is raised.
 
             serial_number: The serial number of the camera.

--- a/openwfs/devices/camera.py
+++ b/openwfs/devices/camera.py
@@ -80,7 +80,8 @@ class Camera(Detector):
                     "GENICAM_GENTL64_PATH and GENICAM_GENTL32_PATH are not set. Check if Basler Pylon is installed or set cti_path manually."
                 )
             # find all cti files in the gentl_path directory and add them to the harvester
-            cti_files = [str(p) for p in Path(gentl_path).glob("*.cti")]
+            cti_files = [str(p) for gp in gentl_path.split(os.pathsep) for p in Path(gp).glob("*.cti")]
+
         else:  # if cti_file is provided, use it directly
             cti_files = [cti_file]
 

--- a/openwfs/devices/camera.py
+++ b/openwfs/devices/camera.py
@@ -41,9 +41,6 @@ class CameraHarvester:
                 )
             self.cti_files.append(cti_file)
 
-    def enumerate_cameras(self):
-        return self._harvester.device_info_list.copy()
-
     @staticmethod
     def get_harvester():
         """Returns the Harvester object for the specified GenTL producer.
@@ -63,6 +60,45 @@ class CameraHarvester:
             global_cam_harvester = weakref.ref(cam_harvester)
 
         return cam_harvester
+
+    def enumerate_cameras(self, cti_file=None):
+        """Enumerates all cameras available through the specified GenTL producer.
+
+        Args:
+            cti_file: The path to the GenTL producer file. If None, the files on the GENICAM_GENTL64_PATH or GENICAM_GENTL32_PATH environment variable will be used.
+
+        Returns:
+            list: A list of device information dictionaries for all available cameras.
+        """
+        if cti_file is None:
+            self.add_cti_files_enviroment_variable()
+        else:
+            self.add_file(cti_file)
+
+        return self._harvester.device_info_list.copy()
+
+    @staticmethod
+    def add_cti_files_enviroment_variable():
+        """
+        Add all CTI files in the directory specified by the GENICAM_GENTL64_PATH or GENICAM_GENTL32_PATH environment variable to the harvester.
+
+        """
+        # for windows use the GENICAM_GENTL64_PATH environment variable, which is set by the Basler pylon installer
+        # by default. Else use the GENICAM_GENTL32_PATH environment variable for 32 bit systems. If neither is set, raise an error.
+        gentl_path = os.environ.get("GENICAM_GENTL64_PATH") or os.environ.get("GENICAM_GENTL32_PATH")
+        if not gentl_path:
+            raise ValueError(
+                "GENICAM_GENTL64_PATH and GENICAM_GENTL32_PATH are not set. Check if Basler Pylon is installed or set cti_path manually."
+            )
+
+        # find all cti files in the gentl_path directory and add them to the harvester
+        cti_files = [str(p) for gp in gentl_path.split(os.pathsep) for p in Path(gp).glob("*.cti")]
+
+        harvester = CameraHarvester.get_harvester()
+
+        # load all cti files in the harvester
+        for cti_file in cti_files:
+            harvester.add_file(cti_file)
 
 
 global_cam_harvester = None
@@ -129,25 +165,11 @@ class Camera(Detector):
         global global_cam_harvester
 
         if cti_file is None:
-            # for windows use the GENICAM_GENTL64_PATH environment variable, which is set by the Basler pylon installer
-            # by default. Else use the GENICAM_GENTL32_PATH environment variable for 32 bit systems. If neither is set, raise an error.
-            gentl_path = os.environ.get("GENICAM_GENTL64_PATH") or os.environ.get("GENICAM_GENTL32_PATH")
-            if not gentl_path:
-                raise ValueError(
-                    "GENICAM_GENTL64_PATH and GENICAM_GENTL32_PATH are not set. Check if Basler Pylon is installed or set cti_path manually."
-                )
-
-            # find all cti files in the gentl_path directory and add them to the harvester
-            cti_files = [str(p) for gp in gentl_path.split(os.pathsep) for p in Path(gp).glob("*.cti")]
-
+            CameraHarvester.add_cti_files_enviroment_variable()
         else:  # if cti_file is provided, use it directly
             cti_files = [cti_file]
 
         self.cam_harvester = CameraHarvester.get_harvester()
-
-        # load all cti files in the harvester
-        for cti_file in cti_files:
-            self.cam_harvester.add_file(cti_file)
 
         # open the camera, use the serial_number to select the camera if it is specified.
         search_key = {"serial_number": serial_number} if serial_number is not None else None
@@ -374,24 +396,6 @@ class Camera(Detector):
     def data_shape(self):
         """Shape (height, width) of the data array returned by the camera."""
         return self.height, self.width
-
-    @staticmethod
-    def enumerate_cameras(cti_file=None):
-        """Enumerates all cameras available through the specified GenTL producer.
-
-        Args:
-            cti_file: The path to the GenTL producer file.
-
-        Returns:
-            list: A list of device information dictionaries for all available cameras.
-
-        Warns:
-            UserWarning: If the CTI file cannot be loaded.
-        """
-        cam_harvester = CameraHarvester.get_harvester()
-        if cti_file is not None:
-            cam_harvester.add_file(cti_file)
-        return cam_harvester.enumerate_cameras()
 
 
 class _CameraPause:

--- a/openwfs/devices/camera.py
+++ b/openwfs/devices/camera.py
@@ -159,8 +159,6 @@ class Camera(Detector):
             **kwargs: Additional keyword arguments.
                 These arguments are transferred to the node map of the camera. They must follow the `genicam` standard.
         """
-        global global_cam_harvester
-
         self.cam_harvester = CameraHarvester.get_harvester()
         if cti_file is None:
             self.cam_harvester.add_cti_files_enviroment_variable()

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -5,6 +5,7 @@ import pytest
 from openwfs.devices import Camera, is_loaded
 import openwfs.devices as opwfs_d
 from openwfs.processors import HDRCamera
+import os
 
 if not is_loaded(harvesters):
     pytest.skip(harvesters.message, allow_module_level=True)
@@ -16,6 +17,11 @@ def camera():
     Fixture that returns a Camera object.
     If no camera is found, the test is skipped.
     """
+    gen_path = os.environ.get("GENICAM_GENTL64_PATH") or os.environ.get("GENICAM_GENTL32_PATH")
+    if gen_path is None:
+        pytest.skip(
+            "GENICAM_GENTL64_PATH or GENICAM_GENTL32_PATH environment variable not set", allow_module_level=True
+        )
     _harvester = opwfs_d.camera.CameraHarvester.get_harvester()
     cameras = _harvester.enumerate_cameras()
     if len(cameras) == 0:

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -27,13 +27,11 @@ def camera():
         pytest.skip("No camera found", allow_module_level=True)
     return Camera()
 
-
 def test_grab(camera):
     frame = camera.read()
     assert frame.shape == camera.data_shape
     assert (camera.height, camera.width) == camera.data_shape
     assert (camera._nodes.Height.value, camera._nodes.Width.value) == camera.data_shape
-    return Camera()
 
 
 def test_hdr(camera):

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -28,6 +28,14 @@ def camera():
     return Camera()
 
 
+def test_grab(camera):
+    frame = camera.read()
+    assert frame.shape == camera.data_shape
+    assert (camera.height, camera.width) == camera.data_shape
+    assert (camera._nodes.Height.value, camera._nodes.Width.value) == camera.data_shape
+    return Camera()
+
+
 def test_hdr(camera):
     """Test the HDR camera functionality.
     Note: this just tests if the code can be run, visual inspection is needed to see if the result is correct."""

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -27,6 +27,7 @@ def camera():
         pytest.skip("No camera found", allow_module_level=True)
     return Camera()
 
+
 def test_grab(camera):
     frame = camera.read()
     assert frame.shape == camera.data_shape

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -3,13 +3,11 @@ import harvesters
 import pytest
 
 from openwfs.devices import Camera, is_loaded
+import openwfs.devices as opwfs_d
 from openwfs.processors import HDRCamera
 
 if not is_loaded(harvesters):
     pytest.skip(harvesters.message, allow_module_level=True)
-
-
-cti_path = R"C:\Program Files\Basler\pylon 7\Runtime\x64\ProducerU3V.cti"
 
 
 @pytest.fixture
@@ -18,17 +16,11 @@ def camera():
     Fixture that returns a Camera object.
     If no camera is found, the test is skipped.
     """
-    cameras = Camera.enumerate_cameras(cti_path)
+    _harvester = opwfs_d.camera.CameraHarvester.get_harvester()
+    cameras = _harvester.enumerate_cameras()
     if len(cameras) == 0:
         pytest.skip("No camera found", allow_module_level=True)
-    return Camera(cti_path)
-
-
-def test_grab(camera):
-    frame = camera.read()
-    assert frame.shape == camera.data_shape
-    assert (camera.height, camera.width) == camera.data_shape
-    assert (camera._nodes.Height.value, camera._nodes.Width.value) == camera.data_shape
+    return Camera()
 
 
 def test_hdr(camera):

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -3,7 +3,6 @@ import harvesters
 import pytest
 
 from openwfs.devices import Camera, is_loaded
-import openwfs.devices as opwfs_d
 from openwfs.processors import HDRCamera
 import os
 
@@ -22,8 +21,8 @@ def camera():
         pytest.skip(
             "GENICAM_GENTL64_PATH or GENICAM_GENTL32_PATH environment variable not set", allow_module_level=True
         )
-    _harvester = opwfs_d.camera.CameraHarvester.get_harvester()
-    cameras = _harvester.enumerate_cameras()
+    cameras = Camera.enumerate_cameras()
+
     if len(cameras) == 0:
         pytest.skip("No camera found", allow_module_level=True)
     return Camera()


### PR DESCRIPTION
Add support for multiple cameras. I thought there was a bug that makes the cameras not being delete correctly when using more than 1 camera. I was trying to reproduce but the example below works fine on linux and windows (so it should be fine):

```python
from openwfs.devices import Camera
import os
import gc

cti_config = "/opt/pylon/lib/gentlproducer/gtl/ProducerU3V.cti"

serial_1 = "23639694"
serial_2 = "23626238"
cam1 = Camera(cti_file = cti_config, serial_number = serial_1)
cam2 = Camera(cti_file = cti_config, serial_number = serial_2)
cam1.read()
cam2.read()

del cam1
del cam2

gc.collect()

cam1 = Camera(cti_file = cti_config, serial_number = serial_1)
cam2 = Camera(cti_file = cti_config, serial_number = serial_2)
cam1.read()
cam2.read()

del cam1
del cam2
```