### PR TITLE
fix bug: to_matrix in Transform could not handle non-isotropic pixel sizes

### DIFF
--- a/openwfs/utilities/utilities.py
+++ b/openwfs/utilities/utilities.py
@@ -165,11 +165,13 @@ class Transform:
     def to_matrix(self, source_pixel_size: CoordinateType, destination_pixel_size: CoordinateType) -> np.ndarray:
         """Returns a homogeneous transformation matrix that transforms (y,x,1) coordinates to (y', x', 1)."""
         matrix = np.eye(3)
-        matrix[0:2, 0:2] = unitless(self.transform * source_pixel_size / destination_pixel_size)
+        A = unitless(np.diag(1.0 / destination_pixel_size) @ self.transform @ np.diag(source_pixel_size))
+        matrix[0:2, 0:2] = A
         if self.destination_origin is not None:
             matrix[0:2, 2] = unitless(self.destination_origin / destination_pixel_size)
         if self.source_origin is not None:
-            matrix[0:2, 2] -= unitless((self.transform @ self.source_origin) / destination_pixel_size)
+            src_origin_px = unitless(self.source_origin / source_pixel_size)
+            matrix[0:2, 2] -= A @ src_origin_px
         return matrix
 
     def opencl_matrix(self) -> np.ndarray:

--- a/openwfs/utilities/utilities.py
+++ b/openwfs/utilities/utilities.py
@@ -165,7 +165,9 @@ class Transform:
     def to_matrix(self, source_pixel_size: CoordinateType, destination_pixel_size: CoordinateType) -> np.ndarray:
         """Returns a homogeneous transformation matrix that transforms (y,x,1) coordinates to (y', x', 1)."""
         matrix = np.eye(3)
-        A = unitless(np.diag(1.0 / np.array(destination_pixel_size)) @ self.transform @ np.diag(np.array(source_pixel_size)))
+        A = unitless(
+            np.diag(1.0 / np.array(destination_pixel_size)) @ self.transform @ np.diag(np.array(source_pixel_size))
+        )
         matrix[0:2, 0:2] = A
         if self.destination_origin is not None:
             matrix[0:2, 2] = unitless(self.destination_origin / destination_pixel_size)

--- a/openwfs/utilities/utilities.py
+++ b/openwfs/utilities/utilities.py
@@ -165,7 +165,7 @@ class Transform:
     def to_matrix(self, source_pixel_size: CoordinateType, destination_pixel_size: CoordinateType) -> np.ndarray:
         """Returns a homogeneous transformation matrix that transforms (y,x,1) coordinates to (y', x', 1)."""
         matrix = np.eye(3)
-        A = unitless(np.diag(1.0 / destination_pixel_size) @ self.transform @ np.diag(source_pixel_size))
+        A = unitless(np.diag(1.0 / np.array(destination_pixel_size)) @ self.transform @ np.diag(np.array(source_pixel_size)))
         matrix[0:2, 0:2] = A
         if self.destination_origin is not None:
             matrix[0:2, 2] = unitless(self.destination_origin / destination_pixel_size)

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -21,7 +21,7 @@ def test_to_matrix():
     # Define the expected output matrix for same input and output pixel sizes
     expected_matrix = np.eye(3)
     result_matrix = transform.to_matrix((1, 2) * u.um, (1, 2) * u.um)
-    print(result_matrix)
+
     assert result_matrix.shape == (3, 3)
     assert np.allclose(result_matrix, expected_matrix)
 
@@ -38,7 +38,7 @@ def test_to_matrix():
     expected_matrix = np.eye(3)
     expected_matrix[0, 0] = 2 * u.um / (1 * u.um)
     result_matrix = transform.to_matrix((2, 2) * u.um, (1, 2) * u.um)
-    print(result_matrix)
+
     assert result_matrix.shape == (3, 3)
     assert np.allclose(result_matrix, expected_matrix)
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -11,7 +11,38 @@ from openwfs.utilities import (
 )
 
 
-def test_to_matrix():
+def test_to_matrix(): 
+    # equal pixel sizes and identity matrix should result in identity matrix
+    transform = Transform(
+        transform=((1,0), (0, 1)),
+        source_origin=(0.0, 0.0) * u.m,
+        destination_origin=(0, 0) * u.mm,
+    )
+    # Define the expected output matrix for same input and output pixel sizes
+    expected_matrix = np.eye(3)
+    result_matrix = transform.to_matrix((1, 2) * u.um, (1, 2) * u.um)
+    print(result_matrix)
+    assert result_matrix.shape == (3, 3)
+    assert np.allclose(result_matrix, expected_matrix)
+
+    # Non equal pixel sizes and identity matrix should be scaled by pixel ratios
+    transform = Transform(
+        transform=((1,0), (0, 1)),
+        source_origin=(0.0, 0.0) * u.m,
+        destination_origin=(0, 0) * u.mm,
+    )
+    # Define the expected output matrix for same input and output pixel sizes
+    # if you want to keep NA coordinates at the same location (identity transform above), but pixels are halv
+    # as small in x direction, you need to move scale by 2 in the x direction, so that the same physical distance 
+    # corresponds to 2 pixels instead of 1 pixel.
+    expected_matrix = np.eye(3)
+    expected_matrix[0, 0] = 2 * u.um / (1 * u.um)
+    result_matrix = transform.to_matrix((2, 2) * u.um, (1, 2) * u.um)
+    print(result_matrix)
+    assert result_matrix.shape == (3, 3)
+    assert np.allclose(result_matrix, expected_matrix)
+
+
     # Create a transform object
     transform = Transform(
         transform=((1, 2), (3, 4)),

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -78,7 +78,7 @@ def test_to_matrix():
     # Repeat for different input and output pixel sizes
     expected_matrix = ((0.5, 8, 1), (0.75, 8, 1), (0, 0, 1))
     result_matrix = transform.to_matrix((0.5, 4) * u.um, (1, 2) * u.um)
-    print(result_matrix)
+
     assert np.allclose(result_matrix, expected_matrix)
 
     # Test center correction. The center of the source image should be mapped to the center of the destination image

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -8,8 +8,10 @@ from openwfs.utilities import (
     place,
     Transform,
     project,
+    set_extent,
 )
 
+from openwfs.utilities.patterns import parabola
 
 def test_to_matrix():
     # equal pixel sizes and identity matrix should result in identity matrix
@@ -188,6 +190,22 @@ def test_transform():
         out_shape=src.shape,
     )
     assert np.allclose(dst1a, dst1b)
+
+    # test that when flipping and rotating, the centre stays the centre, not matter pixel shape
+    transform = Transform(transform = np.array([[0, -1], [-2, 0]]))
+    extent = (5,9)
+    pat = -parabola(extent, 0.5, extent)
+    centre = (pat.shape[0] // 2, pat.shape[1] // 2)
+    max_loc = np.unravel_index(np.argmax(pat), pat.shape)
+    assert max_loc == centre, f"Expected maximum pixel location to be at the center {centre}, but got {max_loc}"
+
+
+    pat = set_extent(pat, extent)
+    pat_extent = (9, 9)
+    pat_big = project(source = pat, out_extent=pat_extent, out_shape=(13, 5), transform=transform)
+    max_loc_big = np.unravel_index(np.argmax(pat_big), pat_big.shape)
+    centre_big = (pat_big.shape[0] // 2, pat_big.shape[1] // 2)
+    assert max_loc_big == centre_big, f"Expected maximum pixel location to be at the center {centre_big}, but got {max_loc_big}"
 
 
 def test_zoom():

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -42,7 +42,26 @@ def test_to_matrix():
     assert result_matrix.shape == (3, 3)
     assert np.allclose(result_matrix, expected_matrix)
 
+    # test off diagonal matrix with anisotropic pixel sizes.
+    # Create a transform object
+    transform = Transform(
+        transform=((1, 2), (3, 4)),
+        source_origin=(0.0, 0.0) * u.m,
+        destination_origin=(0, 0) * u.mm,
+    )
+    # Coordinate (1,0) in physical coordinates is transformed to (1,3) in physical coordinates
+    # 
+    # (1 um ,0) correponds to (1 , 0 ) in pixel coordinates, and (1um, 3um) corresponds to (1, 1.5) in pixel coordinates,
+    # so the first column of the matrix should be (1, 1.5, 0)
+    # Similarly (0,1 um) (corresponds to (0 , 0.5) in pixel coordinates) is transformed to (2um ,4 um) 
+    # (corresponds to (2, 2) in pixel coordinates, for pixel size (1um, 2um))), so the second column of the matrix should be (4, 4, 0)
+    # Define the expected output matrix for same input and output pixel sizes
+    expected_matrix = ((1, 4, 0), (1.5, 4, 0), (0, 0, 1))
+    result_matrix = transform.to_matrix((1, 2) * u.um, (1, 2) * u.um)
+    assert result_matrix.shape == (3, 3)
+    assert np.allclose(result_matrix, expected_matrix)
 
+    # now add a translation of 1 , 1 pixel, for pixel sizes (1um, 2um), this corresponds to a translation of (1um, 2um) in physical coordinates, so the last column of the matrix should be (1, 1.5, 1)
     # Create a transform object
     transform = Transform(
         transform=((1, 2), (3, 4)),
@@ -51,13 +70,13 @@ def test_to_matrix():
     )
 
     # Define the expected output matrix for same input and output pixel sizes
-    expected_matrix = ((1, 2, 1), (3, 4, 1), (0, 0, 1))
+    expected_matrix = ((1, 4, 1), (1.5, 4, 1), (0, 0, 1))
     result_matrix = transform.to_matrix((1, 2) * u.um, (1, 2) * u.um)
     assert result_matrix.shape == (3, 3)
     assert np.allclose(result_matrix, expected_matrix)
 
     # Repeat for different input and output pixel sizes
-    expected_matrix = ((0.5, 4, 1), (1.5, 8, 1), (0, 0, 1))
+    expected_matrix = ((2, 8, 1), (0.75, 8, 1), (0, 0, 1))
     result_matrix = transform.to_matrix((0.5, 4) * u.um, (1, 2) * u.um)
     assert np.allclose(result_matrix, expected_matrix)
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -11,10 +11,10 @@ from openwfs.utilities import (
 )
 
 
-def test_to_matrix(): 
+def test_to_matrix():
     # equal pixel sizes and identity matrix should result in identity matrix
     transform = Transform(
-        transform=((1,0), (0, 1)),
+        transform=((1, 0), (0, 1)),
         source_origin=(0.0, 0.0) * u.m,
         destination_origin=(0, 0) * u.mm,
     )
@@ -27,13 +27,13 @@ def test_to_matrix():
 
     # Non equal pixel sizes and identity matrix should be scaled by pixel ratios
     transform = Transform(
-        transform=((1,0), (0, 1)),
+        transform=((1, 0), (0, 1)),
         source_origin=(0.0, 0.0) * u.m,
         destination_origin=(0, 0) * u.mm,
     )
     # Define the expected output matrix for same input and output pixel sizes
     # if you want to keep NA coordinates at the same location (identity transform above), but pixels are halv
-    # as small in x direction, you need to move scale by 2 in the x direction, so that the same physical distance 
+    # as small in x direction, you need to move scale by 2 in the x direction, so that the same physical distance
     # corresponds to 2 pixels instead of 1 pixel.
     expected_matrix = np.eye(3)
     expected_matrix[0, 0] = 2 * u.um / (1 * u.um)
@@ -50,10 +50,10 @@ def test_to_matrix():
         destination_origin=(0, 0) * u.mm,
     )
     # Coordinate (1,0) in physical coordinates is transformed to (1,3) in physical coordinates
-    # 
+    #
     # (1 um ,0) correponds to (1 , 0 ) in pixel coordinates, and (1um, 3um) corresponds to (1, 1.5) in pixel coordinates,
     # so the first column of the matrix should be (1, 1.5, 0)
-    # Similarly (0,1 um) (corresponds to (0 , 0.5) in pixel coordinates) is transformed to (2um ,4 um) 
+    # Similarly (0,1 um) (corresponds to (0 , 0.5) in pixel coordinates) is transformed to (2um ,4 um)
     # (corresponds to (2, 2) in pixel coordinates, for pixel size (1um, 2um))), so the second column of the matrix should be (4, 4, 0)
     # Define the expected output matrix for same input and output pixel sizes
     expected_matrix = ((1, 4, 0), (1.5, 4, 0), (0, 0, 1))
@@ -76,8 +76,9 @@ def test_to_matrix():
     assert np.allclose(result_matrix, expected_matrix)
 
     # Repeat for different input and output pixel sizes
-    expected_matrix = ((2, 8, 1), (0.75, 8, 1), (0, 0, 1))
+    expected_matrix = ((0.5, 8, 1), (0.75, 8, 1), (0, 0, 1))
     result_matrix = transform.to_matrix((0.5, 4) * u.um, (1, 2) * u.um)
+    print(result_matrix)
     assert np.allclose(result_matrix, expected_matrix)
 
     # Test center correction. The center of the source image should be mapped to the center of the destination image

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -13,6 +13,7 @@ from openwfs.utilities import (
 
 from openwfs.utilities.patterns import parabola
 
+
 def test_to_matrix():
     # equal pixel sizes and identity matrix should result in identity matrix
     transform = Transform(
@@ -192,20 +193,21 @@ def test_transform():
     assert np.allclose(dst1a, dst1b)
 
     # test that when flipping and rotating, the centre stays the centre, not matter pixel shape
-    transform = Transform(transform = np.array([[0, -1], [-2, 0]]))
-    extent = (5,9)
+    transform = Transform(transform=np.array([[0, -1], [-2, 0]]))
+    extent = (5, 9)
     pat = -parabola(extent, 0.5, extent)
     centre = (pat.shape[0] // 2, pat.shape[1] // 2)
     max_loc = np.unravel_index(np.argmax(pat), pat.shape)
     assert max_loc == centre, f"Expected maximum pixel location to be at the center {centre}, but got {max_loc}"
 
-
     pat = set_extent(pat, extent)
     pat_extent = (9, 9)
-    pat_big = project(source = pat, out_extent=pat_extent, out_shape=(13, 5), transform=transform)
+    pat_big = project(source=pat, out_extent=pat_extent, out_shape=(13, 5), transform=transform)
     max_loc_big = np.unravel_index(np.argmax(pat_big), pat_big.shape)
     centre_big = (pat_big.shape[0] // 2, pat_big.shape[1] // 2)
-    assert max_loc_big == centre_big, f"Expected maximum pixel location to be at the center {centre_big}, but got {max_loc_big}"
+    assert (
+        max_loc_big == centre_big
+    ), f"Expected maximum pixel location to be at the center {centre_big}, but got {max_loc_big}"
 
 
 def test_zoom():


### PR DESCRIPTION
Transform could only handle isotropic pixel sizes, but breaks when pixel size not isotropic.

Conversion between pixel numbers  and pixel sizes was not done properly.

_________________________________________________
Example to see issue:
```python
from openwfs.utilities.utilities import get_pixel_size, set_extent, get_extent, Transform, project
from openwfs.utilities.patterns import  parabola
from matplotlib import pyplot as plt
import numpy as np

transform = Transform(transform = np.array([[0, -1], [-1, 0]]))
extent = (5,10)
pat = parabola(extent, 0.5, extent)
plt.imshow(pat, cmap='jet', extent = (-extent[1]/2, extent[1]/2, -extent[0]/2, extent[0]/2), origin='lower')
plt.show()
pat = set_extent(pat, extent)
pat_extent = (14, 18)
pat_big = project(source = pat, out_extent=pat_extent, out_shape=(4*11*2, 4*7), transform=transform)
plt.imshow(pat_big, cmap='jet', extent = (-pat_extent[1]/2, pat_extent[1]/2, -pat_extent[0]/2, pat_extent[0]/2), origin='lower')
plt.show()
```
_________________________________________________
Fix:
1. Convert from pixel numbers to pixel coordinates based on pixel size
2. apply transformation
3. convert back to pixel numbers using the output pixel sizes

Old code assumed that step 1 and 3 could be combined in 1 step, but this is wrong since for matrices A * B * C != B *(A*C), which is what was done in the old situation. That situation did still work for isotropic pixel sizes because for equal pixel sizes terms cancel out. 