### PR TITLE
Fix bug to_matrix

### DIFF
--- a/openwfs/utilities/utilities.py
+++ b/openwfs/utilities/utilities.py
@@ -166,13 +166,13 @@ class Transform:
         """Returns a homogeneous transformation matrix that transforms (y,x,1) coordinates to (y', x', 1)."""
         matrix = np.eye(3)
         A = unitless(
-            np.diag(1.0 / np.array(destination_pixel_size)) @ self.transform @ np.diag(np.array(source_pixel_size))
+            np.diag(1.0 / Quantity(destination_pixel_size)) @ self.transform @ np.diag(Quantity(source_pixel_size))
         )
         matrix[0:2, 0:2] = A
         if self.destination_origin is not None:
-            matrix[0:2, 2] = unitless(self.destination_origin / destination_pixel_size)
+            matrix[0:2, 2] = unitless(Quantity(self.destination_origin) / Quantity(destination_pixel_size))
         if self.source_origin is not None:
-            src_origin_px = unitless(self.source_origin / source_pixel_size)
+            src_origin_px = unitless(Quantity(self.source_origin) / Quantity(source_pixel_size))
             matrix[0:2, 2] -= A @ src_origin_px
         return matrix
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -28,6 +28,15 @@ def test_to_matrix():
     assert result_matrix.shape == (3, 3)
     assert np.allclose(result_matrix, expected_matrix)
 
+    # test that we get identity if units of source and destination are same but have different apparent units (e.g. um / mm)
+    transform = Transform(
+        transform=((1, 0), (0, 1)),
+        source_origin=(0.0, 0.0) * u.m / u.mm,
+        destination_origin=(0, 0) * u.mm / u.m,
+    )
+    result_matrix = transform.to_matrix((1000, 2000) * u.um / u.mm, (1, 2) * u.um / u.um)
+    assert np.allclose(result_matrix, expected_matrix)
+
     # Non equal pixel sizes and identity matrix should be scaled by pixel ratios
     transform = Transform(
         transform=((1, 0), (0, 1)),


### PR DESCRIPTION
np.array(.) removed units without converting to dimensionless quanities first. This gave problems when source and destination pixel sizes had units u.um/u.mm.