### PR TITLE
Adds control to kinesis motorised  flipper

### DIFF
--- a/openwfs/devices/__init__.py
+++ b/openwfs/devices/__init__.py
@@ -79,5 +79,5 @@ from .nidaq_gain import Gain
 from . import slm
 from .slm import SLM
 from .zaber_stage import ZaberXYStage, ZaberLinearStage
-from .kcube_inertial import KCubeInertial
+from .kcube_inertial import KCubeInertial, MotorizedFilterFlip
 from .meadowlark_hdmi import SLMBlinkHDMI

--- a/openwfs/devices/kcube_inertial.py
+++ b/openwfs/devices/kcube_inertial.py
@@ -122,41 +122,41 @@ class KinesisHandler:
     def _find_kinesis_dlls(required_dll_names, folder_path=None):
         """
         Find Kinesis DLL files in a folder.
-        
+
         Arguments:
             folder_path: str or Path or None - Path to the Thorlabs Kinesis folder. If None,
                 defaults to C:\Program Files\Thorlabs\Kinesis.
-            required_dll_names: list of str - Names of required DLL files (e.g., 
+            required_dll_names: list of str - Names of required DLL files (e.g.,
                 ['Thorlabs.MotionControl.DeviceManagerCLI.dll', ...])
-        
+
         Returns:
             list of str - Full paths to found DLL files in the same order as required_dll_names
-        
+
         Raises:
             FileNotFoundError - If folder does not exist or required DLLs are not found
         """
         if folder_path is None:
             folder_path = r"C:\Program Files\Thorlabs\Kinesis"
-        
+
         folder = Path(folder_path)
-        
+
         if not folder.is_dir():
             raise FileNotFoundError(
                 f"Thorlabs Kinesis folder not found: {folder_path}. Ensure that the correct path to "
                 "the Kinesis installation is provided. The software can be downloaded from "
                 "https://www.thorlabs.com/kinesis-software."
             )
-        
+
         found_dlls = []
         missing_dlls = []
-        
+
         for dll_name in required_dll_names:
             dll_path = folder / dll_name
             if dll_path.is_file():
                 found_dlls.append(str(dll_path))
             else:
                 missing_dlls.append(dll_name)
-        
+
         if missing_dlls:
             missing_str = ", ".join(missing_dlls)
             raise FileNotFoundError(
@@ -165,10 +165,8 @@ class KinesisHandler:
                 "is installed in this location. The software can be downloaded from "
                 "https://www.thorlabs.com/kinesis-software."
             )
-        
+
         return found_dlls
-
-
 
 
 global_kinesis_handler = None

--- a/openwfs/devices/kcube_inertial.py
+++ b/openwfs/devices/kcube_inertial.py
@@ -17,7 +17,7 @@ from concurrent.futures import ThreadPoolExecutor
 # A consequence of the use of a separate thread is that the main
 # process cannot try to communicate with the device while the move thread
 # is communicating with the device. For this, function communicating with the
-# device use the function throw_error_if_moving()
+# device use the function KinesisHandler.throw_error_if_moving()
 
 
 class KinesisHandler:
@@ -47,6 +47,86 @@ class KinesisHandler:
             return KinesisHandler([])
         else:
             return global_kinesis_handler
+
+    @staticmethod
+    def disconnect(device):
+        device.StopPolling()
+        device.Disconnect()
+
+    @staticmethod
+    def connect(device):
+        device.device.Connect(device.serial_number)
+        if not device.device.IsConnected:
+            raise ValueError(f"Failed to connect to device with serial number {device.serial_number}.")
+        time.sleep(0.25)
+
+        # Ensure that the device settings have been initialized
+        if not device.device.IsSettingsInitialized():
+            device.device.WaitForSettingsInitialized(10000)  # 10 second timeout
+            if not device.device.IsSettingsInitialized():
+                raise RuntimeError(
+                    f"Device settings failed to initialize within timeout for device with serial number {device.serial_number}."
+                )
+
+        device.device.Connect(device.serial_number)
+        if not device.device.IsConnected:
+            raise ValueError(f"Failed to connect to device with serial number {device.serial_number}.")
+
+        time.sleep(0.25)
+
+        # Ensure that the device settings have been initialized
+        if not device.device.IsSettingsInitialized():
+            device.device.WaitForSettingsInitialized(10000)  # 10 second timeout
+            if not device.device.IsSettingsInitialized():
+                raise RuntimeError(
+                    f"Device settings failed to initialize within timeout for device with serial number {device.serial_number}."
+                )
+
+        # Start polling and enable channel
+        device.device.StartPolling(250)  # 250ms polling rate
+        time.sleep(0.25)
+        
+        device.device.EnableDevice()
+        time.sleep(0.25)  # Wait for device to enable
+
+    @staticmethod
+    def look_for_serialnumber(DeviceManagerCLI, device_code, serial_number):
+        DeviceManagerCLI.BuildDeviceList()
+
+        # The 97 code corresponds to the Kinesis internal code for the KCube Inertial Motor.
+        serial_number_list = list(map(str, DeviceManagerCLI.GetDeviceList(device_code)))
+
+        if serial_number is None:
+            if len(serial_number_list) == 1:
+                serial_number = serial_number_list[0]
+            elif len(serial_number_list) > 1:
+                raise ValueError(
+                    f"Multiple FilterFlipper devices found. Please specify a serial number. Available devices: {serial_number_list}"
+                )
+            else:
+                raise ValueError("No FilterFlipper devices found.")
+
+        if serial_number not in serial_number_list:
+            raise ValueError(
+                f"Device with serial number {serial_number} not found. Available devices: {serial_number_list}"
+            )
+
+        return str(serial_number)
+
+    @staticmethod 
+    def throw_error_if_moving(device):
+        """
+        Convenience function to throw an error if the device is moving or if communication thread is communicating with the device.
+        """
+        if device.busy():
+            raise RuntimeError(
+                "Device is busy. Use self.wait() to wait for the device to finish moving or use self.stop() to stop the device."
+            )
+
+    @staticmethod
+    def disconnect(device):
+        device.device.StopPolling()
+        device.device.Disconnect()
 
 
 global_kinesis_handler = None
@@ -98,51 +178,15 @@ class KCubeInertial(Actuator):
 
         DeviceManagerCLI.BuildDeviceList()
 
-        # The 97 code corresponds to the Kinesis internal code for the KCube Inertial Motor.
-        serial_number_list = list(map(str, DeviceManagerCLI.GetDeviceList(Int32(97))))
+        self.serial_number = KinesisHandler.look_for_serialnumber(DeviceManagerCLI, device_code=KCubeInertialMotor.DevicePrefix, serial_number=serial_number)
 
-        if serial_number is None:
-            if len(serial_number_list) == 1:
-                serial_number = serial_number_list[0]
-            elif len(serial_number_list) > 1:
-                raise ValueError(
-                    f"Multiple KCube Inertial Motor devices found. Please specify a serial number. Available devices: {serial_number_list}"
-                )
-            else:
-                raise ValueError("No KCube Inertial Motor devices found.")
-
-        if serial_number not in serial_number_list:
-            raise ValueError(
-                f"Device with serial number {serial_number} not found. Available devices: {serial_number_list}"
-            )
-
-        # create new device
-        self.serial_number = str(serial_number)  # Serial number of device
         self.device = KCubeInertialMotor.CreateKCubeInertialMotor(self.serial_number)
         self.timeout = timeout
         # Connect
-        self.device.Connect(self.serial_number)
-        if not self.device.IsConnected:
-            raise ValueError(f"Failed to connect to device with serial number {self.serial_number}.")
-
-        time.sleep(0.25)
-
-        # Ensure that the device settings have been initialized
-        if not self.device.IsSettingsInitialized():
-            self.device.WaitForSettingsInitialized(10000)  # 10 second timeout
-            if not self.device.IsSettingsInitialized():
-                raise RuntimeError(
-                    f"Device settings failed to initialize within timeout for device with serial number {self.serial_number}."
-                )
+        KinesisHandler.connect(self)
 
         self._worker = ThreadPoolExecutor(max_workers=1)
         self._future = self._worker.submit(lambda: None)
-
-        # Start polling and enable channel
-        self.device.StartPolling(250)  # 250ms polling rate
-        time.sleep(0.25)
-        self.device.EnableDevice()
-        time.sleep(0.25)  # Wait for device to enable
 
         num_channel = 1 if self.device.IsSingleChannelDevice() else 4
 
@@ -163,8 +207,7 @@ class KCubeInertial(Actuator):
         self._get_velocity_acceleration()
 
     def __del__(self):
-        self.device.StopPolling()
-        self.device.Disconnect()
+        KinesisHandler.disconnect(self)
 
     @property
     def pair_channels(self) -> bool:
@@ -174,7 +217,7 @@ class KCubeInertial(Actuator):
         Returns:
             bool - True if the channels 1 and 2, and 3 and 4 are paired. False otherwise.
         """
-        self.throw_error_if_moving()
+        KinesisHandler.throw_error_if_moving(self)
         return self.device.IsDualChannelMode()
 
     @pair_channels.setter
@@ -186,7 +229,7 @@ class KCubeInertial(Actuator):
             val: bool - True to pair channels 1 with 2, and 3 with 4. False otherwise.
         """
 
-        self.throw_error_if_moving()
+        KinesisHandler.throw_error_if_moving(self)
         self.device.SetDualChannelMode(val)
         time.sleep(0.2)
 
@@ -228,7 +271,7 @@ class KCubeInertial(Actuator):
         self._set_velocity_acceleration(self._velocity, val)
 
     def _set_velocity_acceleration(self, velocity, acceleration):
-        self.throw_error_if_moving()
+        KinesisHandler.throw_error_if_moving(self)
         config = self.device.GetInertialMotorConfiguration(self.serial_number)
         settings = self.ThorlabsInertialMotorSettings.GetSettings(config)
         for i, ch_i in enumerate(self.channels_array):
@@ -238,7 +281,7 @@ class KCubeInertial(Actuator):
         self._get_velocity_acceleration()
 
     def _get_velocity_acceleration(self):
-        self.throw_error_if_moving()
+        KinesisHandler.throw_error_if_moving(self)
         config = self.device.GetInertialMotorConfiguration(self.serial_number)
         settings = self.ThorlabsInertialMotorSettings.GetSettings(config)
         vel = []
@@ -252,7 +295,7 @@ class KCubeInertial(Actuator):
 
     @property
     def position(self) -> np.ndarray:
-        self.throw_error_if_moving()
+        KinesisHandler.throw_error_if_moving(self)
         out = np.zeros(self.channels_array.size, dtype=np.int32)
         for i, ch_i in enumerate(self.channels_array):
             out[i] = self.device.GetPosition(ch_i)
@@ -272,18 +315,10 @@ class KCubeInertial(Actuator):
                 f"Size of position array ({arr.size}) does not match number of channels ({self.channels_array.size})."
             )
 
-        self.throw_error_if_moving()
+        KinesisHandler.throw_error_if_moving(self)
         super()._start()
         self._future = self._worker.submit(self._move_to, arr, self.position, self.pair_channels, True)
 
-    def throw_error_if_moving(self):
-        """
-        Convenience function to throw an error if the device is moving or if communication thread is communicating with the device.
-        """
-        if self.busy():
-            raise RuntimeError(
-                "Device is busy. Use self.wait() to wait for the device to finish moving or use self.stop() to stop the device."
-            )
 
     @staticmethod
     def movement_time(
@@ -355,7 +390,7 @@ class KCubeInertial(Actuator):
                 f"Size of deltas array ({deltas.size}) does not match number of channels ({self.channels_array.size})."
             )
         super()._start()
-        self.throw_error_if_moving()
+        KinesisHandler.throw_error_if_moving(self)
         self._future = self._worker.submit(self._move_to, deltas, self.position, self.pair_channels, False)
 
     def stop(self):
@@ -376,3 +411,106 @@ class KCubeInertial(Actuator):
         # This function works because the thread will be locked by kinesis while a movement
         # is ongoing.
         return not self._future.done()
+
+
+
+class MotorizedFilterFlip(Actuator):
+    """
+    Class to control Motorized Filter Flip (MFF101) from Thorlabs. To use this class the thorlabs Kinesis software must be installed. The software can be downloaded from https://www.thorlabs.com/kinesis-software. The communication with Kinesis is done using pythonnet (clr) which needs to be installed in the python environment.
+
+    Arguments:
+        serial_number: str - Serial number of the device to control. If not provided, the code
+            will try to find a single connected device. If multiple devices are connected,
+            an error is raised.
+        timeout: Quantity [u.s] - Defines the timeout time for the stage when performing
+            movement. Defaults to 20 seconds.
+        kinesis_files: list of str - List of paths to the Kinesis libraries. The libraries needed are Thorlabs.MotionControl.DeviceManagerCLI.dll, Thorlabs.MotionControl.GenericMotorCLI.dll, and Thorlabs.FilterFlipperCLI.dll. If not provided, the code will try to find the libraries in the default installation path of Kinesis (C:\Program Files\Thorlabs\Kinesis).
+    """
+
+    def __init__(
+        self, serial_number: str = None, timeout: u.Quantity = 20 * u.s, kinesis_files=None
+    ):
+
+        if kinesis_files == None:
+            kinesis_files = [
+                r"C:\Program Files\Thorlabs\Kinesis\Thorlabs.MotionControl.DeviceManagerCLI.dll",
+                r"C:\Program Files\Thorlabs\Kinesis\Thorlabs.MotionControl.GenericMotorCLI.dll",
+                r"C:\Program Files\Thorlabs\Kinesis\Thorlabs.MotionControl.FilterFlipperCLI.dll",
+            ]
+
+        kinesis_handler = KinesisHandler.get_handler()
+        kinesis_handler.add_files(kinesis_files)
+
+        from Thorlabs.MotionControl.DeviceManagerCLI import DeviceManagerCLI
+        from Thorlabs.MotionControl.FilterFlipperCLI import (
+            FilterFlipper,
+        )
+        from System import Int32
+
+        self.DeviceManagerCLI = DeviceManagerCLI
+        self.FilterFlipper = FilterFlipper
+        self.Int32 = Int32
+
+        super().__init__(duration=np.inf * u.ms, latency=0 * u.ms)
+
+
+        # create new device
+        self.serial_number = KinesisHandler.look_for_serialnumber(DeviceManagerCLI, device_code=FilterFlipper.DevicePrefix, serial_number=serial_number)
+        self.device = FilterFlipper.CreateFilterFlipper(self.serial_number)
+        self.timeout = timeout
+
+        KinesisHandler.connect(self)
+
+        self._worker = ThreadPoolExecutor(max_workers=1)
+        self._future = self._worker.submit(lambda: None)
+
+
+
+    def __del__(self):
+        KinesisHandler.disconnect(self)
+
+
+    def _move_to(self, pos):
+        """
+            Function to be ran by the thread to move the stage to an absolute position
+
+        Arguments:
+            pos: int - Absolute position to move the device to.
+        """
+        self.device.SetPosition(self.Int32(int(pos)), int(self.timeout.to(u.ms).value))
+
+    def home(self):
+        """
+            Moves the device to the home position (0).
+        """
+        KinesisHandler.throw_error_if_moving(self)
+        super()._start()
+        self._future = self._worker.submit(self.device.Home, int(self.timeout.to(u.ms).value))
+
+    @property
+    def position(self) -> int:
+        KinesisHandler.throw_error_if_moving(self)
+        return self.device.GetPosition()
+
+    @position.setter
+    def position(self, pos: int):
+        """
+            Moves the device to the specified absolute position.
+
+        Arguments:
+            pos: int - Absolute position to move the device to.
+        """
+        KinesisHandler.throw_error_if_moving(self)
+        super()._start()
+        self._future = self._worker.submit(self._move_to, pos)
+
+    def busy(self):
+        """
+        Returns True if the device is currently moving or communicating with the device.
+        """
+        # This function works because the thread will be locked by kinesis while a movement
+        # is ongoing.
+        return not self._future.done()
+
+
+

--- a/openwfs/devices/kcube_inertial.py
+++ b/openwfs/devices/kcube_inertial.py
@@ -58,19 +58,6 @@ class KinesisHandler:
         device.device.Connect(device.serial_number)
         if not device.device.IsConnected:
             raise ValueError(f"Failed to connect to device with serial number {device.serial_number}.")
-        time.sleep(0.25)
-
-        # Ensure that the device settings have been initialized
-        if not device.device.IsSettingsInitialized():
-            device.device.WaitForSettingsInitialized(10000)  # 10 second timeout
-            if not device.device.IsSettingsInitialized():
-                raise RuntimeError(
-                    f"Device settings failed to initialize within timeout for device with serial number {device.serial_number}."
-                )
-
-        device.device.Connect(device.serial_number)
-        if not device.device.IsConnected:
-            raise ValueError(f"Failed to connect to device with serial number {device.serial_number}.")
 
         time.sleep(0.25)
 
@@ -90,21 +77,24 @@ class KinesisHandler:
         time.sleep(0.25)  # Wait for device to enable
 
     @staticmethod
-    def look_for_serialnumber(DeviceManagerCLI, device_code, serial_number):
+    def look_for_serialnumber(DeviceManagerCLI, device_codes, serial_number):
         DeviceManagerCLI.BuildDeviceList()
 
-        # The 97 code corresponds to the Kinesis internal code for the KCube Inertial Motor.
-        serial_number_list = list(map(str, DeviceManagerCLI.GetDeviceList(device_code)))
+        serial_number_list = []
+        for device_code in device_codes:
+            serial_number_list.append(list(map(str, DeviceManagerCLI.GetDeviceList(device_code))))
+        
+        serial_number_list = [item for sublist in serial_number_list for item in sublist]
 
         if serial_number is None:
             if len(serial_number_list) == 1:
                 serial_number = serial_number_list[0]
             elif len(serial_number_list) > 1:
                 raise ValueError(
-                    f"Multiple FilterFlipper devices found. Please specify a serial number. Available devices: {serial_number_list}"
+                    f"Multiple devices found. Please specify a serial number. Available devices: {serial_number_list}"
                 )
             else:
-                raise ValueError("No FilterFlipper devices found.")
+                raise ValueError("No devices found.")
 
         if serial_number not in serial_number_list:
             raise ValueError(
@@ -178,7 +168,7 @@ class KCubeInertial(Actuator):
 
         DeviceManagerCLI.BuildDeviceList()
 
-        self.serial_number = KinesisHandler.look_for_serialnumber(DeviceManagerCLI, device_code=KCubeInertialMotor.DevicePrefix, serial_number=serial_number)
+        self.serial_number = KinesisHandler.look_for_serialnumber(DeviceManagerCLI, device_codes=[KCubeInertialMotor.DevicePrefix_KIM101, KCubeInertialMotor.DevicePrefix_KIM001], serial_number=serial_number)
 
         self.device = KCubeInertialMotor.CreateKCubeInertialMotor(self.serial_number)
         self.timeout = timeout
@@ -455,7 +445,7 @@ class MotorizedFilterFlip(Actuator):
 
 
         # create new device
-        self.serial_number = KinesisHandler.look_for_serialnumber(DeviceManagerCLI, device_code=FilterFlipper.DevicePrefix, serial_number=serial_number)
+        self.serial_number = KinesisHandler.look_for_serialnumber(DeviceManagerCLI, device_codes=[FilterFlipper.DevicePrefix], serial_number=serial_number)
         self.device = FilterFlipper.CreateFilterFlipper(self.serial_number)
         self.timeout = timeout
 

--- a/openwfs/devices/kcube_inertial.py
+++ b/openwfs/devices/kcube_inertial.py
@@ -5,6 +5,7 @@ import time
 import clr
 import os
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 
 # General notes about the implementation of this class:
 # This code uses the DotNET interface from Thorlabs Kinesis to control
@@ -18,6 +19,56 @@ from concurrent.futures import ThreadPoolExecutor
 # process cannot try to communicate with the device while the move thread
 # is communicating with the device. For this, function communicating with the
 # device use the function KinesisHandler.throw_error_if_moving()
+
+
+def _find_kinesis_dlls(folder_path, required_dll_names):
+    """
+    Find Kinesis DLL files in a folder.
+    
+    Arguments:
+        folder_path: str or Path or None - Path to the Thorlabs Kinesis folder. If None,
+            defaults to C:\Program Files\Thorlabs\Kinesis.
+        required_dll_names: list of str - Names of required DLL files (e.g., 
+            ['Thorlabs.MotionControl.DeviceManagerCLI.dll', ...])
+    
+    Returns:
+        list of str - Full paths to found DLL files in the same order as required_dll_names
+    
+    Raises:
+        FileNotFoundError - If folder does not exist or required DLLs are not found
+    """
+    if folder_path is None:
+        folder_path = r"C:\Program Files\Thorlabs\Kinesis"
+    
+    folder = Path(folder_path)
+    
+    if not folder.is_dir():
+        raise FileNotFoundError(
+            f"Thorlabs Kinesis folder not found: {folder_path}. Ensure that the correct path to "
+            "the Kinesis installation is provided. The software can be downloaded from "
+            "https://www.thorlabs.com/kinesis-software."
+        )
+    
+    found_dlls = []
+    missing_dlls = []
+    
+    for dll_name in required_dll_names:
+        dll_path = folder / dll_name
+        if dll_path.is_file():
+            found_dlls.append(str(dll_path))
+        else:
+            missing_dlls.append(dll_name)
+    
+    if missing_dlls:
+        missing_str = ", ".join(missing_dlls)
+        raise FileNotFoundError(
+            f"Required Thorlabs Kinesis DLL files not found in {folder_path}. "
+            f"Missing files: {missing_str}. Ensure that the Kinesis software "
+            "is installed in this location. The software can be downloaded from "
+            "https://www.thorlabs.com/kinesis-software."
+        )
+    
+    return found_dlls
 
 
 class KinesisHandler:
@@ -134,18 +185,20 @@ class KCubeInertial(Actuator):
             (i.e. moving simultaneously). Only important for KIM101.
         timeout: Quantity [u.s] - Defines the timeout time for the stage when performing
             movement. Defaults to 20 seconds.
+        kinesis_folder: str - Path to the Thorlabs Kinesis installation folder. If not provided,
+            defaults to C:\Program Files\Thorlabs\Kinesis.
     """
 
     def __init__(
-        self, serial_number: str = None, pair_channels: bool = False, timeout: u.Quantity = 20 * u.s, kinesis_files=None
+        self, serial_number: str = None, pair_channels: bool = False, timeout: u.Quantity = 20 * u.s, kinesis_folder: str = None
     ):
 
-        if kinesis_files == None:
-            kinesis_files = [
-                r"C:\Program Files\Thorlabs\Kinesis\Thorlabs.MotionControl.DeviceManagerCLI.dll",
-                r"C:\Program Files\Thorlabs\Kinesis\Thorlabs.MotionControl.GenericMotorCLI.dll",
-                r"C:\Program Files\Thorlabs\Kinesis\Thorlabs.MotionControl.KCube.InertialMotorCLI.dll",
-            ]
+        required_dlls = [
+            "Thorlabs.MotionControl.DeviceManagerCLI.dll",
+            "Thorlabs.MotionControl.GenericMotorCLI.dll",
+            "Thorlabs.MotionControl.KCube.InertialMotorCLI.dll",
+        ]
+        kinesis_files = _find_kinesis_dlls(kinesis_folder, required_dlls)
 
         kinesis_handler = KinesisHandler.get_handler()
         kinesis_handler.add_files(kinesis_files)
@@ -414,19 +467,20 @@ class MotorizedFilterFlip(Actuator):
             an error is raised.
         timeout: Quantity [u.s] - Defines the timeout time for the stage when performing
             movement. Defaults to 20 seconds.
-        kinesis_files: list of str - List of paths to the Kinesis libraries. The libraries needed are Thorlabs.MotionControl.DeviceManagerCLI.dll, Thorlabs.MotionControl.GenericMotorCLI.dll, and Thorlabs.FilterFlipperCLI.dll. If not provided, the code will try to find the libraries in the default installation path of Kinesis (C:\Program Files\Thorlabs\Kinesis).
+        kinesis_folder: str - Path to the Thorlabs Kinesis installation folder. If not provided,
+            defaults to C:\Program Files\Thorlabs\Kinesis.
     """
 
     def __init__(
-        self, serial_number: str = None, timeout: u.Quantity = 20 * u.s, kinesis_files=None
+        self, serial_number: str = None, timeout: u.Quantity = 20 * u.s, kinesis_folder: str = None
     ):
 
-        if kinesis_files == None:
-            kinesis_files = [
-                r"C:\Program Files\Thorlabs\Kinesis\Thorlabs.MotionControl.DeviceManagerCLI.dll",
-                r"C:\Program Files\Thorlabs\Kinesis\Thorlabs.MotionControl.GenericMotorCLI.dll",
-                r"C:\Program Files\Thorlabs\Kinesis\Thorlabs.MotionControl.FilterFlipperCLI.dll",
-            ]
+        required_dlls = [
+            "Thorlabs.MotionControl.DeviceManagerCLI.dll",
+            "Thorlabs.MotionControl.GenericMotorCLI.dll",
+            "Thorlabs.MotionControl.FilterFlipperCLI.dll",
+        ]
+        kinesis_files = _find_kinesis_dlls(kinesis_folder, required_dlls)
 
         kinesis_handler = KinesisHandler.get_handler()
         kinesis_handler.add_files(kinesis_files)

--- a/openwfs/devices/kcube_inertial.py
+++ b/openwfs/devices/kcube_inertial.py
@@ -492,11 +492,12 @@ class MotorizedFilterFlip(Actuator):
         from Thorlabs.MotionControl.FilterFlipperCLI import (
             FilterFlipper,
         )
-        from System import Int32
+        from System import Int32, UInt32
 
         self.DeviceManagerCLI = DeviceManagerCLI
         self.FilterFlipper = FilterFlipper
         self.Int32 = Int32
+        self.UInt32 = UInt32
 
         super().__init__(duration=np.inf * u.ms, latency=0 * u.ms)
 
@@ -522,7 +523,8 @@ class MotorizedFilterFlip(Actuator):
         Arguments:
             pos: int - Absolute position to move the device to.
         """
-        self.device.SetPosition(self.Int32(int(pos)), int(self.timeout.to(u.ms).value))
+        print(int(pos))
+        self.device.SetPosition(self.UInt32(int(pos)), int(self.timeout.to(u.ms).value))
 
     def home(self):
         """
@@ -535,10 +537,14 @@ class MotorizedFilterFlip(Actuator):
     @property
     def position(self) -> int:
         KinesisHandler.throw_error_if_moving(self)
-        return self.device.GetPosition()
+        kine_pos = self.device.Position
+        if kine_pos == 2:
+            return True
+        else:
+            return False
 
     @position.setter
-    def position(self, pos: int):
+    def position(self, pos: bool):
         """
             Moves the device to the specified absolute position.
 
@@ -547,7 +553,11 @@ class MotorizedFilterFlip(Actuator):
         """
         KinesisHandler.throw_error_if_moving(self)
         super()._start()
-        self._future = self._worker.submit(self._move_to, pos)
+        if pos:
+            pos_int = 2
+        else:
+            pos_int = 1
+        self._future = self._worker.submit(self._move_to, pos_int)
 
     def busy(self):
         """

--- a/openwfs/devices/kcube_inertial.py
+++ b/openwfs/devices/kcube_inertial.py
@@ -21,56 +21,6 @@ from pathlib import Path
 # device use the function KinesisHandler.throw_error_if_moving()
 
 
-def _find_kinesis_dlls(folder_path, required_dll_names):
-    """
-    Find Kinesis DLL files in a folder.
-
-    Arguments:
-        folder_path: str or Path or None - Path to the Thorlabs Kinesis folder. If None,
-            defaults to C:\Program Files\Thorlabs\Kinesis.
-        required_dll_names: list of str - Names of required DLL files (e.g.,
-            ['Thorlabs.MotionControl.DeviceManagerCLI.dll', ...])
-
-    Returns:
-        list of str - Full paths to found DLL files in the same order as required_dll_names
-
-    Raises:
-        FileNotFoundError - If folder does not exist or required DLLs are not found
-    """
-    if folder_path is None:
-        folder_path = r"C:\Program Files\Thorlabs\Kinesis"
-
-    folder = Path(folder_path)
-
-    if not folder.is_dir():
-        raise FileNotFoundError(
-            f"Thorlabs Kinesis folder not found: {folder_path}. Ensure that the correct path to "
-            "the Kinesis installation is provided. The software can be downloaded from "
-            "https://www.thorlabs.com/kinesis-software."
-        )
-
-    found_dlls = []
-    missing_dlls = []
-
-    for dll_name in required_dll_names:
-        dll_path = folder / dll_name
-        if dll_path.is_file():
-            found_dlls.append(str(dll_path))
-        else:
-            missing_dlls.append(dll_name)
-
-    if missing_dlls:
-        missing_str = ", ".join(missing_dlls)
-        raise FileNotFoundError(
-            f"Required Thorlabs Kinesis DLL files not found in {folder_path}. "
-            f"Missing files: {missing_str}. Ensure that the Kinesis software "
-            "is installed in this location. The software can be downloaded from "
-            "https://www.thorlabs.com/kinesis-software."
-        )
-
-    return found_dlls
-
-
 class KinesisHandler:
     """
     Class to handle the connection with the Kinesis software. This class is used to ensure that the Kinesis software is properly initialized and that the device list is built before trying to connect to a device. This is important because if the device list is not built, the code will not be able to find the device and will raise an error.
@@ -169,6 +119,57 @@ class KinesisHandler:
         device.device.StopPolling()
         device.device.Disconnect()
 
+    def _find_kinesis_dlls(required_dll_names, folder_path=None):
+        """
+        Find Kinesis DLL files in a folder.
+        
+        Arguments:
+            folder_path: str or Path or None - Path to the Thorlabs Kinesis folder. If None,
+                defaults to C:\Program Files\Thorlabs\Kinesis.
+            required_dll_names: list of str - Names of required DLL files (e.g., 
+                ['Thorlabs.MotionControl.DeviceManagerCLI.dll', ...])
+        
+        Returns:
+            list of str - Full paths to found DLL files in the same order as required_dll_names
+        
+        Raises:
+            FileNotFoundError - If folder does not exist or required DLLs are not found
+        """
+        if folder_path is None:
+            folder_path = r"C:\Program Files\Thorlabs\Kinesis"
+        
+        folder = Path(folder_path)
+        
+        if not folder.is_dir():
+            raise FileNotFoundError(
+                f"Thorlabs Kinesis folder not found: {folder_path}. Ensure that the correct path to "
+                "the Kinesis installation is provided. The software can be downloaded from "
+                "https://www.thorlabs.com/kinesis-software."
+            )
+        
+        found_dlls = []
+        missing_dlls = []
+        
+        for dll_name in required_dll_names:
+            dll_path = folder / dll_name
+            if dll_path.is_file():
+                found_dlls.append(str(dll_path))
+            else:
+                missing_dlls.append(dll_name)
+        
+        if missing_dlls:
+            missing_str = ", ".join(missing_dlls)
+            raise FileNotFoundError(
+                f"Required Thorlabs Kinesis DLL files not found in {folder_path}. "
+                f"Missing files: {missing_str}. Ensure that the Kinesis software "
+                "is installed in this location. The software can be downloaded from "
+                "https://www.thorlabs.com/kinesis-software."
+            )
+        
+        return found_dlls
+
+
+
 
 global_kinesis_handler = None
 
@@ -202,7 +203,7 @@ class KCubeInertial(Actuator):
             "Thorlabs.MotionControl.GenericMotorCLI.dll",
             "Thorlabs.MotionControl.KCube.InertialMotorCLI.dll",
         ]
-        kinesis_files = _find_kinesis_dlls(kinesis_folder, required_dlls)
+        kinesis_files = KinesisHandler._find_kinesis_dlls(required_dlls, kinesis_folder)
 
         kinesis_handler = KinesisHandler.get_handler()
         kinesis_handler.add_files(kinesis_files)
@@ -484,7 +485,7 @@ class MotorizedFilterFlip(Actuator):
             "Thorlabs.MotionControl.GenericMotorCLI.dll",
             "Thorlabs.MotionControl.FilterFlipperCLI.dll",
         ]
-        kinesis_files = _find_kinesis_dlls(kinesis_folder, required_dlls)
+        kinesis_files = KinesisHandler._find_kinesis_dlls(required_dlls, kinesis_folder)
 
         kinesis_handler = KinesisHandler.get_handler()
         kinesis_handler.add_files(kinesis_files)

--- a/openwfs/devices/kcube_inertial.py
+++ b/openwfs/devices/kcube_inertial.py
@@ -24,41 +24,41 @@ from pathlib import Path
 def _find_kinesis_dlls(folder_path, required_dll_names):
     """
     Find Kinesis DLL files in a folder.
-    
+
     Arguments:
         folder_path: str or Path or None - Path to the Thorlabs Kinesis folder. If None,
             defaults to C:\Program Files\Thorlabs\Kinesis.
-        required_dll_names: list of str - Names of required DLL files (e.g., 
+        required_dll_names: list of str - Names of required DLL files (e.g.,
             ['Thorlabs.MotionControl.DeviceManagerCLI.dll', ...])
-    
+
     Returns:
         list of str - Full paths to found DLL files in the same order as required_dll_names
-    
+
     Raises:
         FileNotFoundError - If folder does not exist or required DLLs are not found
     """
     if folder_path is None:
         folder_path = r"C:\Program Files\Thorlabs\Kinesis"
-    
+
     folder = Path(folder_path)
-    
+
     if not folder.is_dir():
         raise FileNotFoundError(
             f"Thorlabs Kinesis folder not found: {folder_path}. Ensure that the correct path to "
             "the Kinesis installation is provided. The software can be downloaded from "
             "https://www.thorlabs.com/kinesis-software."
         )
-    
+
     found_dlls = []
     missing_dlls = []
-    
+
     for dll_name in required_dll_names:
         dll_path = folder / dll_name
         if dll_path.is_file():
             found_dlls.append(str(dll_path))
         else:
             missing_dlls.append(dll_name)
-    
+
     if missing_dlls:
         missing_str = ", ".join(missing_dlls)
         raise FileNotFoundError(
@@ -67,7 +67,7 @@ def _find_kinesis_dlls(folder_path, required_dll_names):
             "is installed in this location. The software can be downloaded from "
             "https://www.thorlabs.com/kinesis-software."
         )
-    
+
     return found_dlls
 
 
@@ -123,7 +123,7 @@ class KinesisHandler:
         # Start polling and enable channel
         device.device.StartPolling(250)  # 250ms polling rate
         time.sleep(0.25)
-        
+
         device.device.EnableDevice()
         time.sleep(0.25)  # Wait for device to enable
 
@@ -134,7 +134,7 @@ class KinesisHandler:
         serial_number_list = []
         for device_code in device_codes:
             serial_number_list.append(list(map(str, DeviceManagerCLI.GetDeviceList(device_code))))
-        
+
         serial_number_list = [item for sublist in serial_number_list for item in sublist]
 
         if serial_number is None:
@@ -154,7 +154,7 @@ class KinesisHandler:
 
         return str(serial_number)
 
-    @staticmethod 
+    @staticmethod
     def throw_error_if_moving(device):
         """
         Convenience function to throw an error if the device is moving or if communication thread is communicating with the device.
@@ -190,7 +190,11 @@ class KCubeInertial(Actuator):
     """
 
     def __init__(
-        self, serial_number: str = None, pair_channels: bool = False, timeout: u.Quantity = 20 * u.s, kinesis_folder: str = None
+        self,
+        serial_number: str = None,
+        pair_channels: bool = False,
+        timeout: u.Quantity = 20 * u.s,
+        kinesis_folder: str = None,
     ):
 
         required_dlls = [
@@ -221,7 +225,11 @@ class KCubeInertial(Actuator):
 
         DeviceManagerCLI.BuildDeviceList()
 
-        self.serial_number = KinesisHandler.look_for_serialnumber(DeviceManagerCLI, device_codes=[KCubeInertialMotor.DevicePrefix_KIM101, KCubeInertialMotor.DevicePrefix_KIM001], serial_number=serial_number)
+        self.serial_number = KinesisHandler.look_for_serialnumber(
+            DeviceManagerCLI,
+            device_codes=[KCubeInertialMotor.DevicePrefix_KIM101, KCubeInertialMotor.DevicePrefix_KIM001],
+            serial_number=serial_number,
+        )
 
         self.device = KCubeInertialMotor.CreateKCubeInertialMotor(self.serial_number)
         self.timeout = timeout
@@ -362,7 +370,6 @@ class KCubeInertial(Actuator):
         super()._start()
         self._future = self._worker.submit(self._move_to, arr, self.position, self.pair_channels, True)
 
-
     @staticmethod
     def movement_time(
         distance: int, velocity: u.Quantity[1 / u.s], acceleration: u.Quantity[1 / u.s**2]
@@ -456,7 +463,6 @@ class KCubeInertial(Actuator):
         return not self._future.done()
 
 
-
 class MotorizedFilterFlip(Actuator):
     """
     Class to control Motorized Filter Flip (MFF101) from Thorlabs. To use this class the thorlabs Kinesis software must be installed. The software can be downloaded from https://www.thorlabs.com/kinesis-software. The communication with Kinesis is done using pythonnet (clr) which needs to be installed in the python environment.
@@ -471,9 +477,7 @@ class MotorizedFilterFlip(Actuator):
             defaults to C:\Program Files\Thorlabs\Kinesis.
     """
 
-    def __init__(
-        self, serial_number: str = None, timeout: u.Quantity = 20 * u.s, kinesis_folder: str = None
-    ):
+    def __init__(self, serial_number: str = None, timeout: u.Quantity = 20 * u.s, kinesis_folder: str = None):
 
         required_dlls = [
             "Thorlabs.MotionControl.DeviceManagerCLI.dll",
@@ -497,9 +501,10 @@ class MotorizedFilterFlip(Actuator):
 
         super().__init__(duration=np.inf * u.ms, latency=0 * u.ms)
 
-
         # create new device
-        self.serial_number = KinesisHandler.look_for_serialnumber(DeviceManagerCLI, device_codes=[FilterFlipper.DevicePrefix], serial_number=serial_number)
+        self.serial_number = KinesisHandler.look_for_serialnumber(
+            DeviceManagerCLI, device_codes=[FilterFlipper.DevicePrefix], serial_number=serial_number
+        )
         self.device = FilterFlipper.CreateFilterFlipper(self.serial_number)
         self.timeout = timeout
 
@@ -508,11 +513,8 @@ class MotorizedFilterFlip(Actuator):
         self._worker = ThreadPoolExecutor(max_workers=1)
         self._future = self._worker.submit(lambda: None)
 
-
-
     def __del__(self):
         KinesisHandler.disconnect(self)
-
 
     def _move_to(self, pos):
         """
@@ -525,7 +527,7 @@ class MotorizedFilterFlip(Actuator):
 
     def home(self):
         """
-            Moves the device to the home position (0).
+        Moves the device to the home position (0).
         """
         KinesisHandler.throw_error_if_moving(self)
         super()._start()
@@ -555,6 +557,3 @@ class MotorizedFilterFlip(Actuator):
         # This function works because the thread will be locked by kinesis while a movement
         # is ongoing.
         return not self._future.done()
-
-
-

--- a/openwfs/devices/kcube_inertial.py
+++ b/openwfs/devices/kcube_inertial.py
@@ -523,7 +523,6 @@ class MotorizedFilterFlip(Actuator):
         Arguments:
             pos: int - Absolute position to move the device to.
         """
-        print(int(pos))
         self.device.SetPosition(self.UInt32(int(pos)), int(self.timeout.to(u.ms).value))
 
     def home(self):
@@ -549,7 +548,7 @@ class MotorizedFilterFlip(Actuator):
             Moves the device to the specified absolute position.
 
         Arguments:
-            pos: int - Absolute position to move the device to.
+            pos: bool - Position to move the device to. True for the flipper to be up, False for the flipper to be down.
         """
         KinesisHandler.throw_error_if_moving(self)
         super()._start()

--- a/openwfs/devices/meadowlark_hdmi.py
+++ b/openwfs/devices/meadowlark_hdmi.py
@@ -161,7 +161,6 @@ class SLMBlinkHDMI(SLM):
             if not np.allclose(self.lookup_table, voltage_bits):
                 self.load_lookup_table(voltage_bits)
 
-
     @property
     def temperature(self):
         """

--- a/tests/test_devices/kcube_inertial.py
+++ b/tests/test_devices/kcube_inertial.py
@@ -6,7 +6,6 @@ import time
 # Test KCubeInertial stage. Requires a physical device KIM101 to be connected.
 
 stage = ow_d.KCubeInertial()
-print("asda")
 
 for i in [True, False]:
     stage.pair_channels = i

--- a/tests/test_devices/kcube_inertial.py
+++ b/tests/test_devices/kcube_inertial.py
@@ -6,6 +6,7 @@ import time
 # Test KCubeInertial stage. Requires a physical device KIM101 to be connected.
 
 stage = ow_d.KCubeInertial()
+print("asda")
 
 for i in [True, False]:
     stage.pair_channels = i

--- a/tests/test_devices/kcube_inertial.py
+++ b/tests/test_devices/kcube_inertial.py
@@ -39,28 +39,3 @@ for i in [True, False]:
     assert np.allclose(stage.position, p_f + delta)
 
 del stage
-# stage = 3
-# stage.shutdown()
-
-#
-# class Dummy:
-#     def __init__(self):
-#         self._workers = ThreadPoolExecutor(max_workers=1)
-#         self.value = None
-#
-#     def compute_value(self, *args_, **kwargs_):
-#         print(self.value)
-#         assert 1== 2
-#         return args_[0] * args_[0]
-#
-#     def set_value(self, v):
-#         self._future = self._workers.submit(self.compute_value, v, 2 * v)
-#
-#     def get_value(self):
-#         print(self._future.done())
-#         return self._future.result()
-#
-# d = Dummy()
-# d.set_value(5)
-# d._future.done()
-# print(d.get_value\:0

--- a/tests/test_devices/motorizedflipper.py
+++ b/tests/test_devices/motorizedflipper.py
@@ -1,0 +1,14 @@
+import openwfs.devices as ow_d
+import time
+
+stage = ow_d.MotorizedFilterFlip()
+
+stage.position = 1
+stage.wait()
+assert stage.position == 1
+
+stage.position = 0
+stage.wait()
+assert stage.position == 0
+
+del stage

--- a/tests/test_devices/motorizedflipper.py
+++ b/tests/test_devices/motorizedflipper.py
@@ -1,14 +1,15 @@
 import openwfs.devices as ow_d
-import time
 
 stage = ow_d.MotorizedFilterFlip()
 
-stage.position = 1
+stage.position = True
 stage.wait()
+stage.position
 assert stage.position == 1
 
-stage.position = 0
+stage.position = False
 stage.wait()
+stage.position
 assert stage.position == 0
 
 del stage


### PR DESCRIPTION
Adds control of motorized flipper from thorlabs to openwfs. 

In the previous PR, I changed the tests of hardware (physical devices) to be run only with pytests markers. I did this for safety because I a user could blindly run tests which could, for example move a stage, and creating some physical damage to the physical device. In this manner, tests to physical devices need to be run explicitly being safer. 

